### PR TITLE
chore: refresh release actions and merge state

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Verify exact source revision
         run: test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build and push agent
         id: agent
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./agent
           push: true
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build and push dashboard
         id: dashboard
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./dashboard
           push: true
@@ -94,7 +94,7 @@ jobs:
           --created-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
       - name: Upload immutable release manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ env.RELEASE_SHA }}
           path: ${{ runner.temp }}/release/release.env

--- a/agent/tests/test_release_manifest.py
+++ b/agent/tests/test_release_manifest.py
@@ -352,7 +352,10 @@ def test_deployment_workflows_require_immutable_release_and_approval():
     assert build.count("org.opencontainers.image.source=") == 2
     assert build.count("org.opencontainers.image.revision=") == 2
     assert "actions/attest@v4" in build
-    assert "actions/upload-artifact@v4" in build
+    assert "actions/upload-artifact@v7" in build
+    assert "docker/setup-buildx-action@v4" in build
+    assert "docker/login-action@v4" in build
+    assert build.count("docker/build-push-action@v7") == 2
     assert "--schema-min 45" in build
     assert "--schema-max 45" in build
     assert "workflow_dispatch:" in deploy

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -9,18 +9,15 @@ historiska journalen och ska inte användas som ensam källa för dagens drift.
 
 - Systemet är en fail-closed papertradingplattform. Riktiga pengar och
   brokerkoppling är blockerade.
-- Kanonisk arbetsbranch är `recovery/schema44-2026-08-10` i
-  `diffen77/trading-agent`; namnet är historiskt och branchen innehåller nu
-  schema 45.
-- Draft-PR är [#10](https://github.com/diffen77/trading-agent/pull/10).
-- `main` innehåller ännu inte recovery-arbetet och får därför inte användas
-  som aktuell kodkälla före granskad merge.
+- Kanonisk kod finns på `main` i `diffen77/trading-agent` efter merge av
+  [PR #10](https://github.com/diffen77/trading-agent/pull/10).
+- Mergecommit är `6be95b57f472c5393b01044d52562fb17d7372c5`.
 - PostgreSQL är system of record. Neo4j och Cortex är härledda projekt- och
   tradingminnen, inte ersättning för Git eller ledgern.
 
-## Verifierad lokal kod
+## Verifierad kod och release
 
-Följande ändringar finns som separata commits på recovery-branchen:
+Följande ändringar ingår nu i `main`:
 
 - `dd8edb7`: öppningsrutinens grace beräknas från leverantörens nominella
   fördröjning och tillåtna lagg; fallet 09:20:45 är regressionstestat;
@@ -34,8 +31,10 @@ Följande ändringar finns som separata commits på recovery-branchen:
 På ett nybyggt PostgreSQL 16-schema 45 passerade 664 agenttester och 65
 dashboardtester. Dashboardens produktionsbygge passerade. Den historiska
 leveranskontrollens fem fokustester passerade efter den fulla körningen.
-GitHub Actions ska fortfarande vara grön på slutcommit innan branchen kan
-betraktas som merge-klar.
+GitHub Actions-körning `31464024257` passerade på mergecommitten. Den
+immutabla releasekörningen `31464131315` byggde och pushade revisionsmärkta
+agent- och dashboard-images, attesterade deras proveniens och publicerade
+release-manifestet. Ingen deployment startades.
 
 ## Verifierad staging
 

--- a/docs/MORNING_HANDOFF.md
+++ b/docs/MORNING_HANDOFF.md
@@ -3,8 +3,8 @@
 ## Resultat
 
 Allt säkert internt arbete som kunde göras utan köp, avtal, KYC, riktiga
-pengar, merge till `main` eller operatörens finansiella beslut är genomfört på
-draft-PR #10.
+pengar eller operatörens finansiella beslut är mergat till `main`. CI och den
+immutabla releasebyggnaden är gröna; ingen deployment har gjorts.
 
 Det innebär:
 
@@ -21,10 +21,11 @@ Det innebär:
 
 ## Beslut och externa åtgärder, i ordning
 
-### 1. Granska PR #10
+### 1. PR #10 — klart
 
-Beslut: godkänn eller begär ändringar. Merge till `main` är medvetet inte
-gjord automatiskt.
+PR #10 mergades till `main` som `6be95b57f472c5393b01044d52562fb17d7372c5`.
+Agent- och dashboard-images samt release-manifest byggdes från exakt denna
+revision.
 
 ### 2. Godkänn första schema-45-releasens transition
 

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -5,14 +5,14 @@ medvetet väntar. Detaljerade framtidskrav ligger kvar i `ROADMAP.md`.
 
 | Prioritet | Arbetsström | Status | Nästa verifierbara resultat |
 | --- | --- | --- | --- |
-| P0 | Recovery och GitHub | Implementerad på draft-branch | Slut-CI grön och operatörsgranskning av PR #10 |
+| P0 | Recovery och GitHub | Mergad till `main`, CI och release gröna | Bevara mergecommit och releasekörning i nästa deploymentbevis |
 | P0 | Öppningsrutin | Fixad och regressionstestad | Verifiera nästa öppna XSTO-session efter release |
 | P0 | Releaseproveniens | Implementerad | Första officiella image verifieras commit→digest i staging |
 | P0 | Schema 45-transition | Beslut krävs | Snapshot, underhållsfönster och explicit backout för första release |
 | P1 | Benchmark-preflight | Implementerad lokalt | Kör mot staging efter schema-45-release och lös rapporterade blockerare |
 | P1 | Historisk data | Leveransgate klar, data saknas | Välj licens/produkt, lägg sampleverans och bygg formatadapter |
 | P1 | Kontinuerligt lärande | Automatisk evidens, manuell aktivering | Fortsätt samla sessioner; granska eventuell `DRAFT`-utmanare |
-| P1 | Dokumentation och projektminne | Uppdateras med slutresultat | Cortex och Neo4j verifierade mot slutcommit |
+| P1 | Dokumentation och projektminne | Synkat efter merge | Uppdatera efter nästa bestående driftbeslut |
 | P1 | Forward benchmark | Blockerad av data och beslut | Ren ledger, frysta antaganden och godkänd förregistrering |
 | P1 | Tradinggraf | Shadow-only | Oberoende evidens före eventuell operativ aktivering |
 | P2 | Broker och riktiga pengar | Avsiktligt blockerad | Separat beslut först efter godkänt forward-benchmark |


### PR DESCRIPTION
## Summary
- upgrade release actions to current Node 24-capable major versions
- test all pinned release action contracts
- record PR #10 merge, green main CI, and immutable release evidence

## Verification
- 29 release and git-hook tests passed
- dashboard pre-push tests and production build passed
- no deployment changes