### PR TITLE
docs: record verified schema 45 staging release

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -10,8 +10,11 @@ historiska journalen och ska inte användas som ensam källa för dagens drift.
 - Systemet är en fail-closed papertradingplattform. Riktiga pengar och
   brokerkoppling är blockerade.
 - Kanonisk kod finns på `main` i `diffen77/trading-agent` efter merge av
-  [PR #10](https://github.com/diffen77/trading-agent/pull/10).
-- Mergecommit är `6be95b57f472c5393b01044d52562fb17d7372c5`.
+  [PR #10](https://github.com/diffen77/trading-agent/pull/10) och den
+  efterföljande Actions-uppgraderingen i
+  [PR #11](https://github.com/diffen77/trading-agent/pull/11).
+- Aktuellt main-head och staging-release är
+  `a1ca715380f3e496cddcfc7373205b84adbac4dd`.
 - PostgreSQL är system of record. Neo4j och Cortex är härledda projekt- och
   tradingminnen, inte ersättning för Git eller ledgern.
 
@@ -31,10 +34,10 @@ Följande ändringar ingår nu i `main`:
 På ett nybyggt PostgreSQL 16-schema 45 passerade 664 agenttester och 65
 dashboardtester. Dashboardens produktionsbygge passerade. Den historiska
 leveranskontrollens fem fokustester passerade efter den fulla körningen.
-GitHub Actions-körning `31464024257` passerade på mergecommitten. Den
-immutabla releasekörningen `31464131315` byggde och pushade revisionsmärkta
+GitHub Actions-körning `31464520362` passerade på aktuellt main-head. Den
+immutabla releasekörningen `31464638182` byggde och pushade revisionsmärkta
 agent- och dashboard-images, attesterade deras proveniens och publicerade
-release-manifestet. Ingen deployment startades.
+release-manifestet utan Node 20-varningar.
 
 ## Verifierad staging
 
@@ -46,14 +49,25 @@ Senaste läsverifieringen visade:
 - publik root: `401`;
 - publik health: `200`;
 - operations-API utan auth: `401`;
-- tio Compose-tjänster: `running` och `healthy`;
+- tio långlivade Compose-tjänster: `running` och `healthy`;
 - intern readiness: `READY`;
-- databasschema: 44.
+- databasschema: 45;
+- agent-image:
+  `sha256:dd8b03dd14bc634daf48f52e0e53370c52b0f3457ee3409f8f15f968a4847d1f`;
+- dashboard-image:
+  `sha256:ca095e1e1436c2543df229be3454973b2506d90fad0e8c7b04a1880344bfe8c7`;
+- båda images har OCI-revision
+  `a1ca715380f3e496cddcfc7373205b84adbac4dd`.
 
-Staging har alltså inte nattens schema-45-kod. De nuvarande images saknar
-OCI-revisionslabel. En första schema-45-release får därför inte göras som en
-vanlig automatisk deploy: gammal schema-44-kod är inte en säker rollback efter
-migreringen, och de gamla images kan inte styrkas med den nya provenienskedjan.
+Före migrationen togs och validerades en PostgreSQL-dump samt separata
+snapshots av Compose-konfigurationen och migrationsfilerna. Smoke-testet efter
+deployment verifierade `200` på publik health, `401` utan auth och `200` med
+auth på operations-API:t. Operationsstatus var korrekt `BLOCKED` enbart av
+`XSTO_SESSION_NOT_OPEN` utanför börsens öppettid.
+
+Benchmark-readiness körs nu i staging och är fortsatt fail-closed. De
+kvarvarande blockerarna gäller extern data, ren benchmark-ledger och godkänd
+förregistrering; de är inte driftfel i releasen.
 
 ## Benchmark och lärandeloop
 

--- a/docs/MORNING_HANDOFF.md
+++ b/docs/MORNING_HANDOFF.md
@@ -4,7 +4,8 @@
 
 Allt säkert internt arbete som kunde göras utan köp, avtal, KYC, riktiga
 pengar eller operatörens finansiella beslut är mergat till `main`. CI och den
-immutabla releasebyggnaden är gröna; ingen deployment har gjorts.
+immutabla releasebyggnaden är gröna. Staging kör schema 45 från den verifierade
+releasen `a1ca715380f3e496cddcfc7373205b84adbac4dd`.
 
 Det innebär:
 
@@ -21,20 +22,22 @@ Det innebär:
 
 ## Beslut och externa åtgärder, i ordning
 
-### 1. PR #10 — klart
+### 1. GitHub- och releasekedjan — klart
 
 PR #10 mergades till `main` som `6be95b57f472c5393b01044d52562fb17d7372c5`.
-Agent- och dashboard-images samt release-manifest byggdes från exakt denna
-revision.
+PR #11 uppgraderade release-actions och mergades som aktuellt main-head
+`a1ca715380f3e496cddcfc7373205b84adbac4dd`. De deployade agent- och
+dashboard-images samt release-manifestet byggdes från exakt denna revision.
 
-### 2. Godkänn första schema-45-releasens transition
+### 2. Första schema-45-releasens transition — klart
 
-Beslut: välj ett underhållsfönster och godkänn en engångsplan med
-databassnapshot, verifierad schema-45-deploy och framåtriktad backout.
+En validerad PostgreSQL-dump samt snapshots av Compose-konfiguration och
+migrationsfiler togs före övergången. Schema 45 migrerades, samtliga långlivade
+tjänster startades från digest-låsta images och OCI-revisionen verifierades mot
+GitHub-releasen.
 
-Skäl: staging kör schema 44 och images utan revisionslabel. Efter migrationen
-är automatisk rollback till den gamla koden inte säker. Ingen sådan deploy har
-gjorts under natten.
+Efterkontrollen visar intern readiness `READY`, friska tjänster och korrekt
+operationsblockering `XSTO_SESSION_NOT_OPEN` utanför börsens öppettid.
 
 ### 3. Skaffa den styrda historikleveransen
 
@@ -89,10 +92,6 @@ stängda affärer och godkänt benchmark utan kritiska incidenter.
 
 ## Körordning efter besluten
 
-1. Merge av granskad PR.
-2. Bygg och verifiera officiella revisionsmärkta images.
-3. Ta snapshot och genomför den godkända schema-45-transitionen.
-4. Kör staging-smoke och benchmark `readiness`.
-5. Skaffa och verifiera data; bygg och testa formatadaptern mot samplefiler.
-6. Skapa ren benchmarkmiljö och frys förregistreringen.
-7. Starta forward-benchmarket först när alla maskinella gates är gröna.
+1. Skaffa och verifiera data; bygg och testa formatadaptern mot samplefiler.
+2. Skapa ren benchmarkmiljö och frys förregistreringen.
+3. Starta forward-benchmarket först när alla maskinella gates är gröna.


### PR DESCRIPTION
## Sammanfattning
- dokumenterar verifierad schema 45-deployment på staging
- binder runtime till release a1ca715 och exakta image-digests
- markerar transitionen som klar och lämnar endast externa benchmarkbeslut

## Verifiering
- staging smoke: READY
- samtliga långlivade tjänster: healthy
- schema: 45
- pre-push: 65 dashboardtester och produktionsbygge passerade

Inga kod-, secret- eller .env-ändringar.