### PR TITLE
docs: distinguish deployed release from main head

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -13,7 +13,7 @@ historiska journalen och ska inte användas som ensam källa för dagens drift.
   [PR #10](https://github.com/diffen77/trading-agent/pull/10) och den
   efterföljande Actions-uppgraderingen i
   [PR #11](https://github.com/diffen77/trading-agent/pull/11).
-- Aktuellt main-head och staging-release är
+- Deployad staging-release är
   `a1ca715380f3e496cddcfc7373205b84adbac4dd`.
 - PostgreSQL är system of record. Neo4j och Cortex är härledda projekt- och
   tradingminnen, inte ersättning för Git eller ledgern.

--- a/docs/MORNING_HANDOFF.md
+++ b/docs/MORNING_HANDOFF.md
@@ -25,9 +25,9 @@ Det innebär:
 ### 1. GitHub- och releasekedjan — klart
 
 PR #10 mergades till `main` som `6be95b57f472c5393b01044d52562fb17d7372c5`.
-PR #11 uppgraderade release-actions och mergades som aktuellt main-head
-`a1ca715380f3e496cddcfc7373205b84adbac4dd`. De deployade agent- och
-dashboard-images samt release-manifestet byggdes från exakt denna revision.
+PR #11 uppgraderade release-actions. Den deployade staging-releasen är
+`a1ca715380f3e496cddcfc7373205b84adbac4dd`; agent- och dashboard-images samt
+release-manifestet byggdes från exakt denna revision.
 
 ### 2. Första schema-45-releasens transition — klart
 


### PR DESCRIPTION
## Sammanfattning
Korrigerar två formuleringar så att den digest-låsta staging-releasen a1ca715 inte beskrivs som ett main-head som flyttas vid senare dokumentationscommits.

## Verifiering
- endast två Markdown-filer
- diff check passerad
- pre-push: 65 dashboardtester och produktionsbygge passerade