### PR TITLE
Automate paper policy promotion and rollback

### DIFF
--- a/agent/src/core/continuous_learning.py
+++ b/agent/src/core/continuous_learning.py
@@ -15,6 +15,7 @@ _VALIDATION_SESSIONS = 3
 _MIN_SAMPLE = 100
 _MIN_COVERAGE_PCT = 99.0
 _MIN_FORWARD_IMPROVEMENT_BPS = 2.0
+_ROLLBACK_SESSIONS = 3
 
 
 @dataclass(frozen=True)
@@ -34,6 +35,106 @@ class CandidateCalibrationResult:
     challenger_validation_mean_bps: float | None
     validation_improvement_bps: float | None
     metrics: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CandidateRollbackResult:
+    status: str
+    reason_code: str
+    completed_sessions: int
+    coverage_pct: float
+    active_outcomes: int
+    parent_outcomes: int
+    active_mean_bps: float | None
+    parent_mean_bps: float | None
+    parent_positive_rate_pct: float | None
+    parent_advantage_bps: float | None
+
+
+def evaluate_candidate_policy_rollback(
+    *,
+    completed_sessions: int,
+    coverage_pct: float,
+    active_outcomes: int,
+    parent_outcomes: int,
+    active_mean_bps: float | None,
+    parent_mean_bps: float | None,
+    parent_positive_rate_pct: float | None,
+) -> CandidateRollbackResult:
+    """Gate rollback on bounded post-activation forward evidence."""
+    counts = {
+        "completed_sessions": completed_sessions,
+        "active_outcomes": active_outcomes,
+        "parent_outcomes": parent_outcomes,
+    }
+    if any(
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        for value in counts.values()
+    ):
+        raise ValueError("rollback counts must be non-negative integers")
+    coverage = _bounded_number(coverage_pct, "coverage_pct")
+    if not 0 <= coverage <= 100:
+        raise ValueError("coverage_pct must be between 0 and 100")
+
+    common = {
+        **counts,
+        "coverage_pct": round(coverage, 2),
+        "active_mean_bps": None,
+        "parent_mean_bps": None,
+        "parent_positive_rate_pct": None,
+        "parent_advantage_bps": None,
+    }
+    if coverage < _MIN_COVERAGE_PCT:
+        return CandidateRollbackResult(
+            status="COLLECTING",
+            reason_code="ROLLBACK_OUTCOME_COVERAGE_INCOMPLETE",
+            **common,
+        )
+    if completed_sessions < _ROLLBACK_SESSIONS:
+        return CandidateRollbackResult(
+            status="COLLECTING",
+            reason_code="INSUFFICIENT_ROLLBACK_SESSIONS",
+            **common,
+        )
+    if active_outcomes < _MIN_SAMPLE or parent_outcomes < _MIN_SAMPLE:
+        return CandidateRollbackResult(
+            status="COLLECTING",
+            reason_code="INSUFFICIENT_ROLLBACK_OUTCOMES",
+            **common,
+        )
+    active_mean = _bounded_number(active_mean_bps, "active_mean_bps")
+    parent_mean = _bounded_number(parent_mean_bps, "parent_mean_bps")
+    parent_positive_rate = _bounded_number(
+        parent_positive_rate_pct,
+        "parent_positive_rate_pct",
+    )
+    if not 0 <= parent_positive_rate <= 100:
+        raise ValueError(
+            "parent_positive_rate_pct must be between 0 and 100"
+        )
+    advantage = parent_mean - active_mean
+    rolled_back = (
+        advantage >= _MIN_FORWARD_IMPROVEMENT_BPS
+        and parent_positive_rate >= 50
+    )
+    return CandidateRollbackResult(
+        status="ROLLBACK" if rolled_back else "KEEP",
+        reason_code=(
+            "PARENT_FORWARD_PERFORMANCE_RECOVERED"
+            if rolled_back
+            else "ACTIVE_POLICY_REMAINS_COMPETITIVE"
+        ),
+        completed_sessions=completed_sessions,
+        coverage_pct=round(coverage, 2),
+        active_outcomes=active_outcomes,
+        parent_outcomes=parent_outcomes,
+        active_mean_bps=round(active_mean, 4),
+        parent_mean_bps=round(parent_mean, 4),
+        parent_positive_rate_pct=round(parent_positive_rate, 2),
+        parent_advantage_bps=round(advantage, 4),
+    )
 
 
 def _bounded_number(value: Any, field: str) -> float:
@@ -276,4 +377,3 @@ def calibrate_candidate_policy(
         validation_improvement_bps=round(improvement, 4),
         metrics=metrics,
     )
-

--- a/agent/src/data/database.py
+++ b/agent/src/data/database.py
@@ -8459,6 +8459,329 @@ class Database:
                 "candidate_id": candidate["id"],
             })
 
+    def activate_candidate_policy_automatically(
+        self,
+        version: str,
+        *,
+        activated_at: datetime,
+    ) -> bool:
+        """Atomically review and activate one forward-gated challenger."""
+        if (
+            not isinstance(version, str)
+            or not re.fullmatch(
+                r"[a-z0-9][a-z0-9._-]{2,49}",
+                version,
+            )
+        ):
+            raise ValueError("candidate policy version has invalid format")
+        if (
+            not isinstance(activated_at, datetime)
+            or activated_at.tzinfo is None
+            or activated_at.utcoffset() is None
+        ):
+            raise ValueError("activated_at must be timezone-aware")
+        transition_at = activated_at.astimezone(timezone.utc)
+        actor = "continuous-learning-worker"
+        with self.Session.begin() as session:
+            session.execute(text("""
+                SELECT pg_advisory_xact_lock(
+                    hashtextextended('candidate-policy-activation', 0)
+                )
+            """))
+            candidate = session.execute(text("""
+                SELECT
+                    policy.id,
+                    policy.status,
+                    policy.parent_version_id,
+                    calibration.status AS calibration_status,
+                    parent.status AS parent_status
+                FROM candidate_policy_versions policy
+                JOIN candidate_policy_calibration_runs calibration
+                  ON calibration.id = policy.calibration_run_id
+                JOIN candidate_policy_versions parent
+                  ON parent.id = policy.parent_version_id
+                WHERE policy.version = :version
+                FOR UPDATE OF policy, parent
+            """), {"version": version}).mappings().one_or_none()
+            if candidate is None:
+                raise ValueError(
+                    "forward-gated candidate policy is unavailable"
+                )
+            if candidate["status"] == "ACTIVE":
+                return False
+            if (
+                candidate["status"] not in ("DRAFT", "APPROVED")
+                or candidate["calibration_status"] != "CHALLENGER"
+                or candidate["parent_status"] != "ACTIVE"
+            ):
+                raise ValueError(
+                    "forward-gated candidate policy is unavailable"
+                )
+            session.execute(text("""
+                UPDATE candidate_policy_versions
+                SET
+                    status = 'RETIRED',
+                    retired_at = :transition_at,
+                    updated_at = :transition_at
+                WHERE id = :parent_id
+            """), {
+                "parent_id": candidate["parent_version_id"],
+                "transition_at": transition_at,
+            })
+            session.execute(text("""
+                UPDATE candidate_policy_versions
+                SET
+                    status = 'ACTIVE',
+                    reviewed_by = COALESCE(reviewed_by, :actor),
+                    reviewed_at = COALESCE(reviewed_at, :transition_at),
+                    activated_by = :actor,
+                    activated_at = :transition_at,
+                    updated_at = :transition_at
+                WHERE id = :candidate_id
+            """), {
+                "actor": actor,
+                "candidate_id": candidate["id"],
+                "transition_at": transition_at,
+            })
+        return True
+
+    def rollback_candidate_policy_automatically(
+        self,
+        *,
+        evaluated_at: datetime,
+    ) -> dict:
+        """Restore the parent config after bounded forward regression."""
+        from ..core.candidates import (
+            CandidatePolicy,
+            candidate_policy_hash,
+        )
+        from ..core.continuous_learning import (
+            evaluate_candidate_policy_rollback,
+        )
+
+        if (
+            not isinstance(evaluated_at, datetime)
+            or evaluated_at.tzinfo is None
+            or evaluated_at.utcoffset() is None
+        ):
+            raise ValueError("evaluated_at must be timezone-aware")
+        checked_at = evaluated_at.astimezone(timezone.utc)
+        actor = "continuous-learning-worker"
+        with self.Session.begin() as session:
+            session.execute(text("""
+                SELECT pg_advisory_xact_lock(
+                    hashtextextended('candidate-policy-activation', 0)
+                )
+            """))
+            active = session.execute(text("""
+                SELECT
+                    id,
+                    version,
+                    config,
+                    RTRIM(config_hash) AS config_hash,
+                    parent_version_id,
+                    activated_by,
+                    activated_at
+                FROM candidate_policy_versions
+                WHERE status = 'ACTIVE'
+                FOR UPDATE
+            """)).mappings().one_or_none()
+            if active is None:
+                raise RuntimeError("No active candidate policy exists")
+            if (
+                active["parent_version_id"] is None
+                or active["activated_by"] != actor
+                or active["version"].startswith("xsto-rollback-")
+            ):
+                return {
+                    "status": "WAITING",
+                    "reason_code": "AUTOMATED_CHILD_POLICY_UNAVAILABLE",
+                    "policy_version": active["version"],
+                }
+            parent = session.execute(text("""
+                SELECT
+                    id,
+                    version,
+                    config,
+                    RTRIM(config_hash) AS config_hash
+                FROM candidate_policy_versions
+                WHERE id = :parent_id
+                FOR SHARE
+            """), {
+                "parent_id": active["parent_version_id"],
+            }).mappings().one_or_none()
+            if parent is None:
+                raise RuntimeError("Active policy parent is unavailable")
+            active_policy = CandidatePolicy.from_mapping(
+                version=active["version"],
+                config=active["config"],
+            )
+            parent_policy = CandidatePolicy.from_mapping(
+                version=parent["version"],
+                config=parent["config"],
+            )
+            if (
+                candidate_policy_hash(active_policy)
+                != active["config_hash"]
+                or candidate_policy_hash(parent_policy)
+                != parent["config_hash"]
+            ):
+                raise RuntimeError("Candidate policy config hash mismatch")
+
+            coverage = session.execute(text("""
+                WITH expected AS (
+                    SELECT
+                        prediction.id,
+                        DATE_TRUNC('minute', prediction.observed_at)
+                            + INTERVAL '30 minutes' AS target_at
+                    FROM candidate_predictions prediction
+                    WHERE prediction.policy_version = :policy_version
+                      AND prediction.created_at >= :activated_at
+                      AND prediction.observed_at <= :evaluated_at
+                      AND prediction.expected_horizons_minutes @> ARRAY[30]
+                )
+                SELECT
+                    COUNT(*) FILTER (
+                        WHERE expected.target_at <= :evaluated_at
+                    )::INTEGER AS matured,
+                    COUNT(outcome.id)::INTEGER AS labelled
+                FROM expected
+                LEFT JOIN candidate_prediction_outcomes outcome
+                  ON outcome.prediction_id = expected.id
+                 AND outcome.horizon_minutes = 30
+                 AND outcome.evaluated_at <= :evaluated_at
+            """), {
+                "activated_at": active["activated_at"],
+                "evaluated_at": checked_at,
+                "policy_version": active["version"],
+            }).mappings().one()
+            metrics = session.execute(text("""
+                SELECT
+                    COUNT(DISTINCT market_session.session_date)::INTEGER
+                        AS completed_sessions,
+                    COUNT(*) FILTER (
+                        WHERE prediction.signal_score >= :active_threshold
+                    )::INTEGER AS active_outcomes,
+                    COUNT(*) FILTER (
+                        WHERE prediction.signal_score >= :parent_threshold
+                    )::INTEGER AS parent_outcomes,
+                    AVG(outcome.return_bps) FILTER (
+                        WHERE prediction.signal_score >= :active_threshold
+                    ) AS active_mean_bps,
+                    AVG(outcome.return_bps) FILTER (
+                        WHERE prediction.signal_score >= :parent_threshold
+                    ) AS parent_mean_bps,
+                    100.0 * AVG(
+                        CASE
+                            WHEN outcome.return_bps > 0 THEN 1.0
+                            ELSE 0.0
+                        END
+                    ) FILTER (
+                        WHERE prediction.signal_score >= :parent_threshold
+                    ) AS parent_positive_rate_pct
+                FROM candidate_predictions prediction
+                JOIN candidate_prediction_outcomes outcome
+                  ON outcome.prediction_id = prediction.id
+                 AND outcome.horizon_minutes = 30
+                JOIN market_sessions market_session
+                  ON market_session.mic = 'XSTO'
+                 AND market_session.status IN ('OPEN', 'HALF_DAY')
+                 AND prediction.observed_at >= market_session.opens_at
+                 AND prediction.observed_at < market_session.closes_at
+                 AND outcome.target_event_time < market_session.closes_at
+                WHERE prediction.policy_version = :policy_version
+                  AND prediction.created_at >= :activated_at
+                  AND prediction.reason_code != 'SPREAD_TOO_WIDE'
+                  AND prediction.observed_at <= :evaluated_at
+                  AND outcome.evaluated_at <= :evaluated_at
+            """), {
+                "activated_at": active["activated_at"],
+                "active_threshold": active_policy.min_signal_score,
+                "evaluated_at": checked_at,
+                "parent_threshold": parent_policy.min_signal_score,
+                "policy_version": active["version"],
+            }).mappings().one()
+            matured = int(coverage["matured"] or 0)
+            labelled = int(coverage["labelled"] or 0)
+            decision = evaluate_candidate_policy_rollback(
+                completed_sessions=int(metrics["completed_sessions"] or 0),
+                coverage_pct=(
+                    labelled / matured * 100 if matured else 0.0
+                ),
+                active_outcomes=int(metrics["active_outcomes"] or 0),
+                parent_outcomes=int(metrics["parent_outcomes"] or 0),
+                active_mean_bps=metrics["active_mean_bps"],
+                parent_mean_bps=metrics["parent_mean_bps"],
+                parent_positive_rate_pct=(
+                    metrics["parent_positive_rate_pct"]
+                ),
+            )
+            result = {
+                field.name: getattr(decision, field.name)
+                for field in fields(decision)
+            }
+            if decision.status != "ROLLBACK":
+                return {
+                    **result,
+                    "policy_version": active["version"],
+                }
+
+            rollback_version = f"xsto-rollback-{active['id']}"
+            session.execute(text("""
+                UPDATE candidate_policy_versions
+                SET
+                    status = 'RETIRED',
+                    retired_at = :evaluated_at,
+                    updated_at = :evaluated_at
+                WHERE id = :active_id
+            """), {
+                "active_id": active["id"],
+                "evaluated_at": checked_at,
+            })
+            session.execute(text("""
+                INSERT INTO candidate_policy_versions (
+                    version,
+                    status,
+                    config,
+                    config_hash,
+                    parent_version_id,
+                    proposed_by,
+                    reviewed_by,
+                    reviewed_at,
+                    activated_by,
+                    activated_at
+                )
+                VALUES (
+                    :version,
+                    'ACTIVE',
+                    CAST(:config AS JSONB),
+                    :config_hash,
+                    :parent_version_id,
+                    :actor,
+                    :actor,
+                    :evaluated_at,
+                    :actor,
+                    :evaluated_at
+                )
+            """), {
+                "actor": actor,
+                "config": json.dumps(
+                    parent_policy.to_config(),
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+                "config_hash": parent["config_hash"],
+                "evaluated_at": checked_at,
+                "parent_version_id": active["id"],
+                "version": rollback_version,
+            })
+            return {
+                **result,
+                "policy_version": rollback_version,
+            }
+
     def reject_candidate_policy_version(
         self,
         version: str,

--- a/agent/src/learning_worker.py
+++ b/agent/src/learning_worker.py
@@ -23,6 +23,8 @@ class LearningCycleResult:
     outcomes_labelled: int
     calibration_run_id: int | None
     calibration_status: str | None
+    policy_action: str | None
+    policy_version: str | None
     error_code: str | None
 
     def to_dict(self) -> dict:
@@ -53,6 +55,8 @@ def run_learning_cycle(
     run_key = _run_key(checked_at)
     outcomes_labelled = 0
     calibration = None
+    policy_action = None
+    policy_version = None
     error_code = None
     try:
         outcomes_labelled = (
@@ -76,6 +80,41 @@ def run_learning_cycle(
                 "continuous_learning_failed stage=policy_calibration"
             )
             error_code = "POLICY_CALIBRATION_FAILED"
+
+    if (
+        error_code is None
+        and calibration
+        and calibration.get("status") == "CHALLENGER"
+    ):
+        policy_version = calibration.get("challenger_policy_version")
+        try:
+            if not isinstance(policy_version, str) or not policy_version:
+                raise RuntimeError(
+                    "forward challenger is missing its policy version"
+                )
+            activated = database.activate_candidate_policy_automatically(
+                policy_version,
+                activated_at=checked_at,
+            )
+            policy_action = "ACTIVATED" if activated else "ALREADY_ACTIVE"
+        except Exception:
+            logger.exception(
+                "continuous_learning_failed stage=policy_activation"
+            )
+            error_code = "POLICY_ACTIVATION_FAILED"
+    elif error_code is None:
+        try:
+            rollback = database.rollback_candidate_policy_automatically(
+                evaluated_at=checked_at,
+            )
+            if rollback.get("status") == "ROLLBACK":
+                policy_action = "ROLLED_BACK"
+                policy_version = rollback.get("policy_version")
+        except Exception:
+            logger.exception(
+                "continuous_learning_failed stage=policy_rollback"
+            )
+            error_code = "POLICY_ROLLBACK_FAILED"
 
     status = "FAILED" if error_code else "SUCCEEDED"
     calibration_run_id = (
@@ -107,6 +146,8 @@ def run_learning_cycle(
             outcomes_labelled=outcomes_labelled,
             calibration_run_id=calibration_run_id,
             calibration_status=calibration_status,
+            policy_action=policy_action,
+            policy_version=policy_version,
             error_code="RUN_EVIDENCE_PERSISTENCE_FAILED",
         )
 
@@ -116,6 +157,8 @@ def run_learning_cycle(
         outcomes_labelled=outcomes_labelled,
         calibration_run_id=calibration_run_id,
         calibration_status=calibration_status,
+        policy_action=policy_action,
+        policy_version=policy_version,
         error_code=error_code,
     )
 
@@ -172,10 +215,13 @@ def main(
         )
         logger.info(
             "continuous_learning_cycle status=%s outcomes=%d "
-            "calibration_status=%s error_code=%s",
+            "calibration_status=%s policy_action=%s "
+            "policy_version=%s error_code=%s",
             result.status,
             result.outcomes_labelled,
             result.calibration_status,
+            result.policy_action,
+            result.policy_version,
             result.error_code,
         )
         sleeper(interval)

--- a/agent/tests/test_continuous_learning.py
+++ b/agent/tests/test_continuous_learning.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, timedelta, timezone
 
 from src.core.continuous_learning import (
     calibrate_candidate_policy,
+    evaluate_candidate_policy_rollback,
 )
 
 
@@ -68,3 +69,48 @@ def test_calibration_rejects_incomplete_outcome_coverage():
     assert result.status == "COLLECTING"
     assert result.reason_code == "OUTCOME_COVERAGE_INCOMPLETE"
 
+
+def test_rollback_waits_for_three_complete_sessions():
+    result = evaluate_candidate_policy_rollback(
+        completed_sessions=2,
+        coverage_pct=100,
+        active_outcomes=200,
+        parent_outcomes=300,
+        active_mean_bps=-5,
+        parent_mean_bps=5,
+        parent_positive_rate_pct=60,
+    )
+
+    assert result.status == "COLLECTING"
+    assert result.reason_code == "INSUFFICIENT_ROLLBACK_SESSIONS"
+
+
+def test_rollback_restores_parent_after_bounded_forward_regression():
+    result = evaluate_candidate_policy_rollback(
+        completed_sessions=3,
+        coverage_pct=100,
+        active_outcomes=120,
+        parent_outcomes=240,
+        active_mean_bps=-4,
+        parent_mean_bps=3,
+        parent_positive_rate_pct=55,
+    )
+
+    assert result.status == "ROLLBACK"
+    assert result.reason_code == "PARENT_FORWARD_PERFORMANCE_RECOVERED"
+    assert result.parent_advantage_bps == 7
+
+
+def test_rollback_keeps_active_policy_without_clear_regression():
+    result = evaluate_candidate_policy_rollback(
+        completed_sessions=3,
+        coverage_pct=100,
+        active_outcomes=120,
+        parent_outcomes=240,
+        active_mean_bps=4,
+        parent_mean_bps=3,
+        parent_positive_rate_pct=55,
+    )
+
+    assert result.status == "KEEP"
+    assert result.reason_code == "ACTIVE_POLICY_REMAINS_COMPETITIVE"

--- a/agent/tests/test_database_integration.py
+++ b/agent/tests/test_database_integration.py
@@ -5793,6 +5793,153 @@ def test_continuous_candidate_journal_labels_forward_outcomes(
     assert db.get_active_candidate_policy().min_signal_score == 60
 
 
+def test_forward_challenger_can_be_automatically_activated(
+    clean_database,
+    connection,
+    monkeypatch,
+):
+    db = clean_database
+    transition_at = datetime.now(timezone.utc).replace(microsecond=0)
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO candidate_policy_calibration_runs (
+                calibration_key,
+                policy_version,
+                evaluated_at,
+                session_cutoff_date,
+                status,
+                reason_code,
+                train_sessions,
+                validation_sessions,
+                train_outcomes,
+                validation_outcomes,
+                coverage_pct,
+                active_min_signal_score,
+                challenger_min_signal_score,
+                baseline_validation_mean_bps,
+                challenger_validation_mean_bps,
+                validation_improvement_bps,
+                metrics
+            )
+            VALUES (
+                'candidate:xsto-momentum-v1:auto-forward-test',
+                'xsto-momentum-v1',
+                %s,
+                %s,
+                'CHALLENGER',
+                'FORWARD_GATE_PASSED',
+                10,
+                3,
+                1000,
+                300,
+                100,
+                0,
+                60,
+                1,
+                6,
+                5,
+                '{}'::JSONB
+            )
+            RETURNING id
+            """,
+            (transition_at, transition_at.date()),
+        )
+        calibration_id = int(cursor.fetchone()[0])
+        cursor.execute(
+            """
+            INSERT INTO candidate_policy_versions (
+                version,
+                status,
+                config,
+                config_hash,
+                parent_version_id,
+                calibration_run_id,
+                proposed_by
+            )
+            SELECT
+                'xsto-challenger-auto-test',
+                'DRAFT',
+                '{"max_spread_bps":250,"min_signal_score":60}'::JSONB,
+                %s,
+                id,
+                %s,
+                'continuous-learning-worker'
+            FROM candidate_policy_versions
+            WHERE status = 'ACTIVE'
+            """,
+            (
+                "f7d4611347849d783cc71b04c71d07381"
+                "f3f838ed16d1e4516c551bc966eb38b",
+                calibration_id,
+            ),
+        )
+
+    assert db.activate_candidate_policy_automatically(
+        "xsto-challenger-auto-test",
+        activated_at=transition_at,
+    )
+    assert not db.activate_candidate_policy_automatically(
+        "xsto-challenger-auto-test",
+        activated_at=transition_at,
+    )
+    assert db.get_active_candidate_policy().version == (
+        "xsto-challenger-auto-test"
+    )
+    rows = db.query(
+        """
+        SELECT version, status, reviewed_by, activated_by
+        FROM candidate_policy_versions
+        ORDER BY id
+        """
+    )
+    assert rows[0]["status"] == "RETIRED"
+    assert rows[1]["status"] == "ACTIVE"
+    assert rows[1]["reviewed_by"] == "continuous-learning-worker"
+    assert rows[1]["activated_by"] == "continuous-learning-worker"
+
+    from src.core import continuous_learning
+
+    monkeypatch.setattr(
+        continuous_learning,
+        "evaluate_candidate_policy_rollback",
+        lambda **_metrics: continuous_learning.CandidateRollbackResult(
+            status="ROLLBACK",
+            reason_code="PARENT_FORWARD_PERFORMANCE_RECOVERED",
+            completed_sessions=3,
+            coverage_pct=100,
+            active_outcomes=100,
+            parent_outcomes=100,
+            active_mean_bps=-1,
+            parent_mean_bps=6,
+            parent_positive_rate_pct=55,
+            parent_advantage_bps=7,
+        ),
+    )
+    rollback = db.rollback_candidate_policy_automatically(
+        evaluated_at=transition_at + timedelta(days=3),
+    )
+    assert rollback["status"] == "ROLLBACK"
+    assert rollback["policy_version"].startswith("xsto-rollback-")
+    restored = db.get_active_candidate_policy()
+    assert restored.version == rollback["policy_version"]
+    assert restored.min_signal_score == 0
+    rows = db.query(
+        """
+        SELECT version, status, proposed_by, activated_by
+        FROM candidate_policy_versions
+        ORDER BY id
+        """
+    )
+    assert [row["status"] for row in rows] == [
+        "RETIRED",
+        "RETIRED",
+        "ACTIVE",
+    ]
+    assert rows[2]["proposed_by"] == "continuous-learning-worker"
+    assert rows[2]["activated_by"] == "continuous-learning-worker"
+
+
 def test_knowledge_shadow_journal_is_idempotent_and_append_only(
     clean_database,
     connection,

--- a/agent/tests/test_learning_worker.py
+++ b/agent/tests/test_learning_worker.py
@@ -22,6 +22,13 @@ def test_learning_cycle_labels_outcomes_and_calibrates_when_market_is_closed():
                 "reason_code": "INSUFFICIENT_SESSIONS",
             }
 
+        def rollback_candidate_policy_automatically(self, *, evaluated_at):
+            return {
+                "status": "KEEP",
+                "reason_code": "ACTIVE_POLICY_REMAINS_COMPETITIVE",
+                "policy_version": "xsto-momentum-v1",
+            }
+
         def record_continuous_learning_run(self, **values):
             events.append(values)
             return 5
@@ -53,3 +60,74 @@ def test_learning_cycle_records_bounded_failure_evidence():
     assert events[0]["status"] == "FAILED"
     assert "private database detail" not in str(events)
 
+
+def test_learning_cycle_automatically_activates_forward_challenger():
+    activations = []
+    events = []
+
+    class Database:
+        def record_candidate_prediction_outcomes(self, *, evaluated_at):
+            return 3
+
+        def run_candidate_policy_calibration(self, *, evaluated_at):
+            return {
+                "id": 9,
+                "status": "CHALLENGER",
+                "reason_code": "FORWARD_GATE_PASSED",
+                "challenger_policy_version": "xsto-challenger-9",
+            }
+
+        def activate_candidate_policy_automatically(
+            self,
+            version,
+            *,
+            activated_at,
+        ):
+            activations.append((version, activated_at))
+            return True
+
+        def record_continuous_learning_run(self, **values):
+            events.append(values)
+            return 7
+
+    result = run_learning_cycle(Database(), evaluated_at=NOW)
+
+    assert result.status == "SUCCEEDED"
+    assert result.policy_action == "ACTIVATED"
+    assert result.policy_version == "xsto-challenger-9"
+    assert activations == [("xsto-challenger-9", NOW)]
+    assert events[0]["status"] == "SUCCEEDED"
+
+
+def test_learning_cycle_automatically_rolls_back_regressed_policy():
+    events = []
+
+    class Database:
+        def record_candidate_prediction_outcomes(self, *, evaluated_at):
+            return 8
+
+        def run_candidate_policy_calibration(self, *, evaluated_at):
+            return {
+                "id": 10,
+                "status": "COLLECTING",
+                "reason_code": "INSUFFICIENT_SESSIONS",
+            }
+
+        def rollback_candidate_policy_automatically(self, *, evaluated_at):
+            assert evaluated_at == NOW
+            return {
+                "status": "ROLLBACK",
+                "reason_code": "PARENT_FORWARD_PERFORMANCE_RECOVERED",
+                "policy_version": "xsto-rollback-2",
+            }
+
+        def record_continuous_learning_run(self, **values):
+            events.append(values)
+            return 8
+
+    result = run_learning_cycle(Database(), evaluated_at=NOW)
+
+    assert result.status == "SUCCEEDED"
+    assert result.policy_action == "ROLLED_BACK"
+    assert result.policy_version == "xsto-rollback-2"
+    assert events[0]["status"] == "SUCCEEDED"

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -79,8 +79,13 @@ en paper-ledger som inte är ren.
 Den kontinuerliga kandidatloopen är redan aktivt säkerhetsdelad:
 
 - utfall och kalibrering kan köras automatiskt dygnet runt;
-- en statistiskt godkänd utmanarpolicy skapas endast som `DRAFT`;
-- godkännande och aktivering kräver två uttryckliga operatörskommandon;
+- en utmanarpolicy aktiveras automatiskt i paper trading först när den har
+  klarat det tidsordnade framåttestet;
+- efter aktivering följs den mot moderpolicyn under minst tre fullständiga
+  handelssessioner och minst 100 märkta utfall per policy;
+- moderpolicyn återställs automatiskt som en ny, spårbar policyversion om den
+  slår den aktiva policyn med minst två baspunkter och minst hälften av dess
+  utfall är positiva;
 - den äldre textbaserade trade-reviewn skapar inga `learnings` innan styrd
   historisk marknadsdata har importerats.
 

--- a/docs/MORNING_HANDOFF.md
+++ b/docs/MORNING_HANDOFF.md
@@ -17,8 +17,8 @@ Det innebär:
 - schema 45 med starkare bindning mellan datavalidering och exakt
   referenssnapshot;
 - checksummebunden leveranskontroll för all historik som krävs före backtest;
-- verifierad separation mellan automatisk kalibrering och manuell
-  policyaktivering.
+- automatisk aktivering av framåttestade kandidatpolicyer i paper trading,
+  med automatisk återställning efter verifierad försämring.
 
 ## Beslut och externa åtgärder, i ordning
 

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -11,7 +11,7 @@ medvetet väntar. Detaljerade framtidskrav ligger kvar i `ROADMAP.md`.
 | P0 | Schema 45-transition | Beslut krävs | Snapshot, underhållsfönster och explicit backout för första release |
 | P1 | Benchmark-preflight | Implementerad lokalt | Kör mot staging efter schema-45-release och lös rapporterade blockerare |
 | P1 | Historisk data | Leveransgate klar, data saknas | Välj licens/produkt, lägg sampleverans och bygg formatadapter |
-| P1 | Kontinuerligt lärande | Automatisk evidens, manuell aktivering | Fortsätt samla sessioner; granska eventuell `DRAFT`-utmanare |
+| P1 | Kontinuerligt lärande | Automatisk evidens, aktivering och återställning i paper trading | Fortsätt samla sessioner och följ policyövergångarnas evidens |
 | P1 | Dokumentation och projektminne | Synkat efter merge | Uppdatera efter nästa bestående driftbeslut |
 | P1 | Forward benchmark | Blockerad av data och beslut | Ren ledger, frysta antaganden och godkänd förregistrering |
 | P1 | Tradinggraf | Shadow-only | Oberoende evidens före eventuell operativ aktivering |

--- a/docs/continuous-improvement-loop.md
+++ b/docs/continuous-improvement-loop.md
@@ -16,8 +16,10 @@ The first useful loop is:
 3. record every candidate considered, including `HOLD` and `ABSTAIN`;
 4. label each prediction from later, independently persisted book evidence;
 5. report coverage and forward returns by action and score band;
-6. let the model propose observations, while strategy activation remains an
-   explicit operator action.
+6. activate only forward-gated candidate policies automatically in paper
+   trading and restore the parent configuration after bounded regression;
+7. let the model propose observations without granting it a code-writing or
+   real-money execution path.
 
 ## Non-goals and safety boundaries
 
@@ -154,6 +156,9 @@ interpretation that may support a separate strategy proposal.
 
 The legacy trade-review path therefore remains fail-closed until authorised
 historical bars and corporate actions have been imported. Candidate-policy
-calibration may create a `DRAFT` challenger automatically, but an operator must
-approve it and then activate it through two distinct actions. Neither step is
-performed by the learning worker.
+calibration may create a `DRAFT` challenger automatically. In paper trading,
+the learning worker activates it automatically only after the forward gate
+passes. It then compares the active threshold with its parent over at least
+three completed sessions and 100 labelled outcomes per policy. A clear
+regression restores the parent configuration as a new, auditable policy
+version. This does not authorise real-money trading.


### PR DESCRIPTION
## Sammanfattning
- aktiverar automatiskt en kandidatpolicy först efter godkänt tidsordnat framåttest
- jämför den aktiva policyn mot moderpolicyn efter aktivering
- återställer automatiskt moderpolicyn som en ny spårbar version vid tydlig försämring
- gäller enbart paper trading; ingen broker- eller real-money-väg tillkommer

## Verifiering
- 670 Python-tester passerar mot isolerad PostgreSQL 16
- 65 dashboardtester passerar (6 avsiktligt skippade)
- dashboardens typkontroll och produktionsbuild passerar
- separat databasintegrationstest verifierar atomisk aktivering, idempotens och återställning