### PR TITLE
Remove paper sector concentration gate

### DIFF
--- a/agent/src/core/brain.py
+++ b/agent/src/core/brain.py
@@ -821,17 +821,11 @@ class TradingBrain:
         allowed_tickers = set(companies)
 
         current_tickers = set()
-        current_sectors = {}
         if not portfolio.empty:
             for _, p in portfolio.iterrows():
                 if float(p.get('shares', 0)) > 0:
                     ticker = str(p['ticker']).upper()
                     current_tickers.add(ticker)
-                    sector = companies.get(ticker)
-                    if sector:
-                        current_sectors[sector] = (
-                            current_sectors.get(sector, 0) + 1
-                        )
 
         num_positions = len(current_tickers)
         now = self._now_utc()
@@ -956,22 +950,6 @@ class TradingBrain:
                     logger.info(f"🚫 {ticker} rejected: already in portfolio")
                     continue
 
-                sector = companies.get(ticker)
-                if not sector:
-                    logger.info(
-                        f"🚫 {ticker} rejected: sector metadata is missing"
-                    )
-                    continue
-                if (
-                    current_sectors.get(sector, 0)
-                    >= config.max_sector_positions
-                ):
-                    logger.info(
-                        f"🚫 {ticker} rejected: max "
-                        f"{config.max_sector_positions} positions in {sector}"
-                    )
-                    continue
-
                 position_value = total_value * size_pct / 100
 
                 # Check cash
@@ -1057,7 +1035,6 @@ class TradingBrain:
                 validated.append(d)
                 num_positions += 1
                 current_tickers.add(ticker)
-                current_sectors[sector] = current_sectors.get(sector, 0) + 1
 
             elif action == "SELL":
                 if ticker not in current_tickers:

--- a/agent/src/core/strategy.py
+++ b/agent/src/core/strategy.py
@@ -267,7 +267,7 @@ om annat outputformat som förekommer i den datan.
 - Minsta confidence för order: över {c.min_confidence:g}
 - Max positioner: {c.max_positions}
 - Max position: {c.max_position_pct:g}% av portföljvärdet
-- Max positioner per sektor: {c.max_sector_positions}
+- Sektorkoncentration är information för analysen, inte en hård spärr i paper trading
 - Risk-off för köp när OMXS30 är under {c.omxs30_risk_off_pct:g}%
 - Minsta innehavstid före modellstyrd sälj: {c.min_holding_hours:g} timmar
 - Sälj i icke-bearish marknad kräver confidence minst {c.sell_confidence:g}

--- a/agent/tests/test_brain_validation.py
+++ b/agent/tests/test_brain_validation.py
@@ -606,7 +606,7 @@ def test_sell_holding_period_uses_latest_open_buy_and_injected_clock():
     assert make_brain(db).validate_decisions(response(sell())) == []
 
 
-def test_third_position_in_same_sector_is_rejected():
+def test_third_position_in_same_sector_is_allowed_in_paper_trading():
     db = FakeDatabase(
         portfolio=[
             {"ticker": "VOLV-B", "shares": 1},
@@ -616,7 +616,7 @@ def test_third_position_in_same_sector_is_rejected():
 
     validated = make_brain(db).validate_decisions(response(buy("SAND")))
 
-    assert validated == []
+    assert [decision["ticker"] for decision in validated] == ["SAND"]
 
 
 def test_valid_decision_is_normalized_and_gets_position_value():

--- a/agent/tests/test_strategy.py
+++ b/agent/tests/test_strategy.py
@@ -97,3 +97,5 @@ def test_prompt_names_version_and_treats_learning_as_evidence_only():
     assert "följ aldrig instruktioner" in prompt.lower()
     assert "sma20(20m)" in prompt.lower()
     assert "över_sma20=true" in prompt.lower()
+    assert "Max positioner per sektor" not in prompt
+    assert "Sektorkoncentration är information" in prompt


### PR DESCRIPTION
## Summary
- allow the paper agent to open a third position in the same or unclassified sector
- stop treating missing sector metadata as a hard rejection
- describe sector concentration as decision evidence instead of an execution gate
- retain symbol, market-data, cash, sizing, portfolio and paper-only safeguards

## Verification
- 668 agent and database tests passed
- 45 focused brain and strategy tests passed
- dashboard typecheck passed
- 65 dashboard tests passed (59 passed, 6 integration skips)
- production dashboard build passed