### PR TITLE
Retry paper execution quotes during sync commits

### DIFF
--- a/agent/src/core/brain.py
+++ b/agent/src/core/brain.py
@@ -11,6 +11,7 @@ import hashlib
 import logging
 import math
 from datetime import date, datetime, timedelta, timezone
+from time import sleep
 from typing import Dict, Any, List, Optional
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
@@ -353,8 +354,26 @@ class TradingBrain:
             "get_latest_authorized_execution_quote",
             None,
         )
+        quote_checked_at = now
         if callable(execution_reader):
-            quote = execution_reader(ticker, action=action, now=now)
+            quote = None
+            for attempt in range(4):
+                quote = execution_reader(
+                    ticker,
+                    action=action,
+                    now=quote_checked_at,
+                )
+                if quote is not None:
+                    break
+                if attempt < 3:
+                    logger.info(
+                        "Execution quote for %s is unavailable; "
+                        "retrying in 5 seconds (%d/3)",
+                        ticker,
+                        attempt + 1,
+                    )
+                    sleep(5)
+                    quote_checked_at = self._now_utc()
         else:
             # Compatibility for older adapters; the production Database always
             # supplies the action-specific execution reader.
@@ -378,7 +397,7 @@ class TradingBrain:
             ) from exc
         assert_fresh_quote(
             quote,
-            now=now,
+            now=quote_checked_at,
             policy=FreshnessPolicy(
                 max_delay=timedelta(minutes=max_delay_minutes),
                 tolerance=timedelta(minutes=tolerance_minutes),

--- a/agent/tests/test_brain_validation.py
+++ b/agent/tests/test_brain_validation.py
@@ -686,6 +686,94 @@ def test_public_pretrade_buy_uses_book_side_and_intraday_warmup():
     assert validated[0]["source_book_state_id"] == 73
 
 
+def test_public_pretrade_buy_retries_during_batch_commit(monkeypatch):
+    checked_at = datetime(2026, 7, 29, 10, 0, tzinfo=timezone.utc)
+    retry_at = checked_at + timedelta(seconds=5)
+    calls = []
+    sleeps = []
+    db = FakeDatabase()
+    db.require_operational_market_data = lambda _now: {
+        "provider": "nasdaq-nordic",
+        "data_type": "delayed-pre-trade-equity",
+        "eligible_instrument_count": 1,
+        "expected_instrument_count": 1,
+    }
+
+    def execution_quote(ticker, *, action, now):
+        calls.append((ticker, action, now))
+        if len(calls) == 1:
+            return None
+        return QuoteRecord(
+            book_state_id=74,
+            isin="SE0000115446",
+            mic="XSTO",
+            event_time=now - timedelta(minutes=15),
+            received_at=now,
+            source="nasdaq-nordic-public-pretrade",
+            last_price=101,
+            currency="SEK",
+            volume=1000,
+        )
+
+    db.get_latest_authorized_execution_quote = execution_quote
+    db.get_authorized_intraday_signal = lambda ticker, *, now, window: {
+        "ticker": ticker,
+        "session_date": now.date(),
+        "book_state_id": 74,
+        "sma20": 100,
+        "window": window,
+    }
+    brain = make_brain(db)
+    clock = iter((checked_at, retry_at))
+    brain._now_utc = lambda: next(clock)
+    monkeypatch.setattr(
+        brain_module,
+        "sleep",
+        lambda seconds: sleeps.append(seconds),
+        raising=False,
+    )
+
+    validated = brain.validate_decisions(response(buy()))
+
+    assert [decision["ticker"] for decision in validated] == ["VOLV-B"]
+    assert calls == [
+        ("VOLV-B", "BUY", checked_at),
+        ("VOLV-B", "BUY", retry_at),
+    ]
+    assert sleeps == [5]
+
+
+def test_execution_quote_retry_is_bounded(monkeypatch):
+    checked_at = datetime(2026, 7, 29, 10, 0, tzinfo=timezone.utc)
+    calls = []
+    sleeps = []
+    db = FakeDatabase()
+
+    def missing_quote(ticker, *, action, now):
+        calls.append((ticker, action, now))
+        return None
+
+    db.get_latest_authorized_execution_quote = missing_quote
+    brain = make_brain(db)
+    clock = iter(
+        checked_at + timedelta(seconds=5 * attempt)
+        for attempt in range(4)
+    )
+    brain._now_utc = lambda: next(clock)
+    monkeypatch.setattr(
+        brain_module,
+        "sleep",
+        lambda seconds: sleeps.append(seconds),
+        raising=False,
+    )
+
+    validated = brain.validate_decisions(response(buy()))
+
+    assert validated == []
+    assert len(calls) == 4
+    assert sleeps == [5, 5, 5]
+
+
 def test_stale_intraday_quote_blocks_buy():
     db = FakeDatabase()
     def stale_quote(_ticker):


### PR DESCRIPTION
## Summary
- retry a missing action-specific execution quote up to three times at five-second intervals
- refresh the validation clock for every retry
- preserve strict two-sided book, quantity, provenance and freshness checks
- log each bounded retry for runtime evidence

## Root cause
The 13:39 CEST brain cycle overlapped the minute-batch transaction. Candidate analysis completed, but validation read the previous one-sided book before the next batch committed. The same deployed reader returned valid quotes for all three candidates immediately after commit.

## Verification
- regression test failed before the implementation and passed after it
- bounded retry test proves four total reads and three sleeps maximum
- 42 brain validation tests passed
- 672 agent tests passed across the full suite plus the Git-enabled hook rerun
- dashboard typecheck passed
- 65 dashboard tests passed (59 passed, 6 integration skips)
- production dashboard build passed