### PR TITLE
Make sector concentration advisory in paper operations

### DIFF
--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -437,7 +437,7 @@ export default function Dashboard() {
               </div>
               <div className="mt-2 space-y-1 text-xs text-gray-400">
                 <div>Positioner: {ops.risk.open_positions}/{ops.risk.max_positions}</div>
-                <div>Största sektor: {ops.risk.largest_sector_positions}/{ops.risk.max_sector_positions}</div>
+                <div>Sektorkoncentration (info): {ops.risk.largest_sector_positions} positioner</div>
                 <div>Oprissatta positioner: {ops.risk.unpriced_positions}</div>
                 <div>Riskregler för nya köp: {ops.risk.entry_status === 'ACTIVE' && !ops.risk.daily_loss_breached ? 'öppna' : 'stoppade'}</div>
                 <div>Daglig gräns: −{fmtDec(ops.risk.max_daily_loss_pct, 2)}%</div>
@@ -846,7 +846,7 @@ function PositionCard({ pos }: { pos: Position }) {
 }
 
 function RSIBadge({ rsi }: { rsi: number }) {
-  const color = rsi > 70 ? 'bg-red-900/30 text-red-400' : rsi < 30 ? 'bg-green-900/30 text-green-400' : 'bg-gray-800 text-gray-500'
+  const color = rsi > 70 ? 'bg-red-900/30 text-red-400' : rsi < 30 ? 'bg-green-900/30 text-green-400' : 'bg-gray-800 text-white/90'
   const label = rsi > 70 ? 'Överköpt' : rsi < 30 ? 'Översåld' : 'RSI'
   return <span className={`px-1.5 py-0.5 rounded ${color}`}>{label} {fmtDec(rsi, 0)}</span>
 }
@@ -869,7 +869,7 @@ function DecisionCard({ decision }: { decision: Decision }) {
 
   const outlook = parsed.market_outlook || 'neutral'
   const decs = parsed.decisions || []
-  const outlookColor = outlook === 'bullish' ? 'bg-green-900/30 text-green-400' : outlook === 'bearish' ? 'bg-red-900/30 text-red-400' : 'bg-gray-800 text-gray-400'
+  const outlookColor = outlook === 'bullish' ? 'bg-green-900/30 text-green-400' : outlook === 'bearish' ? 'bg-red-900/30 text-red-400' : 'bg-gray-800 text-white/90'
   const time = new Date(decision.timestamp).toLocaleTimeString('sv-SE', { hour: '2-digit', minute: '2-digit' })
   const date = new Date(decision.timestamp).toLocaleDateString('sv-SE')
 

--- a/dashboard/lib/server/operational-status.mjs
+++ b/dashboard/lib/server/operational-status.mjs
@@ -933,12 +933,6 @@ export function buildOperationalStatus(snapshot) {
   if (maxPositions > 0 && openPositions > maxPositions) {
     blockers.push('POSITION_LIMIT_BREACH')
   }
-  if (
-    maxSectorPositions > 0
-    && largestSectorPositions > maxSectorPositions
-  ) {
-    blockers.push('SECTOR_LIMIT_BREACH')
-  }
   if (unpricedPositions > 0) {
     blockers.push('UNPRICED_POSITION')
   }
@@ -961,6 +955,7 @@ export function buildOperationalStatus(snapshot) {
       alert.severity === 'PAGE'
       && typeof code === 'string'
       && /^[A-Z][A-Z0-9_]{2,63}$/.test(code)
+      && code !== 'SECTOR_LIMIT_BREACH'
       && !blockers.includes(code)
     ) {
       blockers.push(code)
@@ -979,7 +974,6 @@ export function buildOperationalStatus(snapshot) {
   )
   const riskHasBreach = blockers.some(code => (
     code === 'POSITION_LIMIT_BREACH'
-    || code === 'SECTOR_LIMIT_BREACH'
     || code === 'UNPRICED_POSITION'
     || code === 'TRADING_HALTED'
     || code === 'DAILY_LOSS_LIMIT_BREACHED'

--- a/dashboard/tests/operational-status.test.mjs
+++ b/dashboard/tests/operational-status.test.mjs
@@ -194,7 +194,7 @@ test('public delayed pre-trade needs executable books but no paid aliases or ind
 })
 
 
-test('risk breaches, unpriced positions and incidents remain visible', () => {
+test('hard risk breaches, unpriced positions and incidents remain visible', () => {
   const snapshot = readySnapshot()
   snapshot.risk = {
     ...snapshot.risk,
@@ -209,11 +209,37 @@ test('risk breaches, unpriced positions and incidents remain visible', () => {
   assert.equal(status.overall_status, 'BLOCKED')
   assert.deepEqual(status.blockers, [
     'POSITION_LIMIT_BREACH',
-    'SECTOR_LIMIT_BREACH',
     'UNPRICED_POSITION',
     'CRITICAL_BENCHMARK_INCIDENT',
   ])
   assert.equal(status.risk.status, 'BREACH')
+})
+
+
+test('sector concentration is visible without blocking paper trading', () => {
+  const snapshot = readySnapshot()
+  snapshot.risk.largest_sector_positions = 3
+  snapshot.operational_alerts = [{
+    alert_key: 'risk:sector',
+    code: 'SECTOR_LIMIT_BREACH',
+    severity: 'PAGE',
+    state: 'OPEN',
+    summary: 'Historisk sektorspärr passerad.',
+    runbook: 'docs/operations.md',
+    observed_at: '2026-08-11T12:01:00.000Z',
+  }]
+
+  const status = buildOperationalStatus(snapshot)
+
+  assert.equal(status.overall_status, 'READY')
+  assert.deepEqual(status.blockers, [])
+  assert.equal(status.risk.status, 'WITHIN_LIMITS')
+  assert.equal(status.risk.largest_sector_positions, 3)
+  assert.equal(status.risk.max_sector_positions, 2)
+  assert.deepEqual(
+    status.monitoring.active_alerts.map(alert => alert.code),
+    ['SECTOR_LIMIT_BREACH'],
+  )
 })
 
 

--- a/dashboard/tests/operations-ui.test.mjs
+++ b/dashboard/tests/operations-ui.test.mjs
@@ -28,6 +28,11 @@ test('dashboard fetches and renders operational readiness evidence', () => {
   assert.match(page, /ops\.monitoring\.scheduled_routines/)
   assert.match(page, /Aktiva driftlarm/)
   assert.match(page, /Senaste schemakörningar/)
+  assert.match(page, /Sektorkoncentration \(info\)/)
+  assert.doesNotMatch(
+    page,
+    /largest_sector_positions\}\/\{ops\.risk\.max_sector_positions/,
+  )
   assert.match(page, /operations\.activation_actions/)
   assert.match(page, /<ActivationQueue/)
   assert.match(activationQueue, /Aktiveringskö/)


### PR DESCRIPTION
## Summary
- stop treating paper-sector concentration as an operations blocker
- keep the measured concentration visible as advisory evidence
- prevent a historical open SECTOR_LIMIT_BREACH alert from latching operations after the policy changed
- clarify the dashboard label and improve two small neutral-badge contrast issues

## Runtime evidence
The sector-free e76bc6e agent autonomously bought Attendo as the third Unclassified position at 11:50:33 UTC. The remaining dashboard rule then blocked operations, proving it was stale policy rather than a trading failure. The attempted dcfa52a deployment rolled back automatically and preserved the trade and ledger.

## Verification
- operational-status regression was red before the change and green after it
- 66 dashboard tests passed (60 passed, 6 integration skips)
- dashboard typecheck and production build passed
- Impeccable detector returned no deterministic findings