### PR TITLE
Allow liquidity-capped paper fills

### DIFF
--- a/agent/src/core/brain.py
+++ b/agent/src/core/brain.py
@@ -10,6 +10,7 @@ import json
 import hashlib
 import logging
 import math
+from decimal import Decimal, InvalidOperation, ROUND_DOWN
 from datetime import date, datetime, timedelta, timezone
 from time import sleep
 from typing import Dict, Any, List, Optional
@@ -914,6 +915,14 @@ class TradingBrain:
             d['source_book_state_id'] = quote.book_state_id
             d['price_event_time'] = quote.event_time
             d['price_source'] = quote.source
+            if quote.book_state_id is not None:
+                if quote.volume is None or quote.volume <= 0:
+                    logger.info(
+                        f"🚫 {ticker} rejected: executable book quantity "
+                        "is missing"
+                    )
+                    continue
+                d['executable_quantity'] = float(quote.volume)
 
             if confidence <= config.min_confidence:
                 logger.info(
@@ -1167,6 +1176,9 @@ class TradingBrain:
                         'source_book_state_id': d.get(
                             'source_book_state_id'
                         ),
+                        'executable_quantity': d.get(
+                            'executable_quantity'
+                        ),
                         'idempotency_key': idempotency_key,
                         'decision_id': decision_id,
                         'decision_origin': 'AI_DECISION',
@@ -1190,13 +1202,59 @@ class TradingBrain:
                     if price is None:
                         continue
                     price = float(price)
+                    if d.get('source_book_state_id') is not None:
+                        try:
+                            executable_quantity = Decimal(
+                                str(d.get('executable_quantity'))
+                            )
+                        except (InvalidOperation, TypeError, ValueError):
+                            logger.info(
+                                f"🚫 {ticker} SELL rejected: executable "
+                                "book quantity is invalid"
+                            )
+                            continue
+                        if (
+                            not executable_quantity.is_finite()
+                            or executable_quantity <= 0
+                        ):
+                            logger.info(
+                                f"🚫 {ticker} SELL rejected: executable "
+                                "book quantity is invalid"
+                            )
+                            continue
+                        executable_quantity = executable_quantity.quantize(
+                            Decimal('0.0001'),
+                            rounding=ROUND_DOWN,
+                        )
+                        if executable_quantity <= 0:
+                            logger.info(
+                                f"🚫 {ticker} SELL rejected: executable "
+                                "book quantity is below trade precision"
+                            )
+                            continue
+                        original_shares = shares
+                        shares = float(min(
+                            Decimal(str(shares)),
+                            executable_quantity,
+                        ).quantize(
+                            Decimal('0.0001'),
+                            rounding=ROUND_DOWN,
+                        ))
+                        if shares < original_shares:
+                            logger.info(
+                                f"Partial SELL {ticker}: capped from "
+                                f"{original_shares:.4f} to {shares:.4f} "
+                                "shares by executable book quantity"
+                            )
 
                     trade = {
                         'ticker': ticker,
                         'action': 'SELL',
                         'shares': shares,
                         'price': price,
-                        'total_value': shares * price,
+                        'total_value': float((
+                            Decimal(str(shares)) * Decimal(str(price))
+                        ).quantize(Decimal('0.01'))),
                         'reasoning': d.get('reason', 'AI sell decision'),
                         'confidence': d.get('confidence', 70),
                         'hypothesis': f"AI exit: {d.get('reason', '')}",

--- a/agent/src/core/trader.py
+++ b/agent/src/core/trader.py
@@ -12,6 +12,7 @@ import logging
 import math
 import hashlib
 import os
+from decimal import Decimal, InvalidOperation, ROUND_DOWN
 from time import sleep
 from typing import Dict, Any, List
 from datetime import datetime, timedelta, timezone
@@ -174,7 +175,67 @@ class PaperTrader:
                 )
                 return False
 
-        shares = position_size / current_price
+        try:
+            desired_notional = Decimal(str(position_size))
+            price_decimal = Decimal(str(current_price))
+        except (InvalidOperation, TypeError, ValueError):
+            logger.error(f"Invalid position size for {ticker}")
+            return False
+        if not desired_notional.is_finite() or desired_notional <= 0:
+            logger.error(f"Invalid position size for {ticker}")
+            return False
+        desired_shares = (desired_notional / price_decimal).quantize(
+            Decimal('0.0001'),
+            rounding=ROUND_DOWN,
+        )
+        if desired_shares <= 0:
+            logger.error(f"Position size is too small for {ticker}")
+            return False
+
+        shares_decimal = desired_shares
+        if source_book_state_id is not None:
+            try:
+                executable_quantity = Decimal(
+                    str(opportunity.get('executable_quantity'))
+                )
+            except (InvalidOperation, TypeError, ValueError):
+                logger.error(
+                    f"Invalid executable book quantity for {ticker}"
+                )
+                return False
+            if (
+                not executable_quantity.is_finite()
+                or executable_quantity <= 0
+            ):
+                logger.error(
+                    f"Invalid executable book quantity for {ticker}"
+                )
+                return False
+            executable_quantity = executable_quantity.quantize(
+                Decimal('0.0001'),
+                rounding=ROUND_DOWN,
+            )
+            if executable_quantity <= 0:
+                logger.error(
+                    f"Executable book quantity is too small for {ticker}"
+                )
+                return False
+            shares_decimal = min(desired_shares, executable_quantity)
+            if shares_decimal < desired_shares:
+                logger.info(
+                    f"Partial BUY {ticker}: capped from "
+                    f"{desired_shares:.4f} to {shares_decimal:.4f} "
+                    "shares by executable book quantity"
+                )
+
+        shares = float(shares_decimal)
+        position_notional = (shares_decimal * price_decimal).quantize(
+            Decimal('0.01')
+        )
+        if position_notional <= 0:
+            logger.error(f"Executable notional is too small for {ticker}")
+            return False
+        position_size = float(position_notional)
         
         # Check we have enough cash for buys
         if action == 'BUY':

--- a/agent/tests/test_brain_validation.py
+++ b/agent/tests/test_brain_validation.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 
 import src.core.brain as brain_module
@@ -682,6 +683,7 @@ def test_public_pretrade_buy_uses_book_side_and_intraday_warmup():
     validated = make_brain(db).validate_decisions(response(buy()))
 
     assert validated[0]["execution_price"] == 101
+    assert validated[0]["executable_quantity"] == 1000
     assert validated[0]["source_quote_id"] is None
     assert validated[0]["source_book_state_id"] == 73
 
@@ -1077,7 +1079,9 @@ def test_ai_execution_propagates_parent_decision_id_to_trade():
             "reason": "Momentum",
             "position_value": 2_000,
             "execution_price": 100,
-            "source_quote_id": 41,
+            "executable_quantity": 12.5,
+            "source_quote_id": None,
+            "source_book_state_id": 41,
         }],
         Trader(),
         cycle_key="brain:test-cycle",
@@ -1088,3 +1092,39 @@ def test_ai_execution_propagates_parent_decision_id_to_trade():
     assert len(executed) == 1
     assert captured[0]["decision_id"] == 73
     assert captured[0]["decision_origin"] == "AI_DECISION"
+    assert captured[0]["executable_quantity"] == 12.5
+
+
+def test_ai_sell_caps_fill_to_executable_book_quantity():
+    captured = []
+
+    class SellDatabase:
+        def get_portfolio(self):
+            return pd.DataFrame([{"ticker": "VOLV-B", "shares": 10}])
+
+        def log_trade_result(self, trade):
+            captured.append(trade)
+            return SimpleNamespace(trade_id=19, inserted=True)
+
+    brain = make_brain()
+    brain.db = SellDatabase()
+    executed = brain.execute_decisions(
+        [{
+            "action": "SELL",
+            "ticker": "VOLV-B",
+            "confidence": 90,
+            "reason": "Exit",
+            "execution_price": 100,
+            "executable_quantity": 3,
+            "source_quote_id": None,
+            "source_book_state_id": 81,
+        }],
+        object(),
+        cycle_key="brain:test-partial-sell",
+        strategy=baseline_strategy(),
+        decision_id=74,
+    )
+
+    assert len(executed) == 1
+    assert captured[0]["shares"] == 3
+    assert captured[0]["total_value"] == 300

--- a/agent/tests/test_trader_idempotency.py
+++ b/agent/tests/test_trader_idempotency.py
@@ -100,11 +100,45 @@ def test_paper_trader_accepts_exact_pretrade_book_state():
     candidate = opportunity(
         source_quote_id=None,
         source_book_state_id=73,
+        executable_quantity=1_000,
     )
 
     assert trader.execute_trade(candidate) is True
     assert database.logged_trade["source_quote_id"] is None
     assert database.logged_trade["source_book_state_id"] == 73
+
+
+def test_paper_trader_caps_pretrade_buy_to_executable_quantity():
+    database = FakeDatabase()
+    trader = PaperTrader(database)
+
+    candidate = opportunity(
+        source_quote_id=None,
+        source_book_state_id=73,
+        executable_quantity=3,
+    )
+
+    assert trader.execute_trade(candidate) is True
+    assert database.logged_trade["shares"] == 3
+    assert database.logged_trade["total_value"] == 300
+
+
+@pytest.mark.parametrize(
+    "quantity",
+    [None, 0, -1, 0.00001, float("inf")],
+)
+def test_paper_trader_rejects_invalid_pretrade_executable_quantity(quantity):
+    database = FakeDatabase()
+    trader = PaperTrader(database)
+
+    assert trader.execute_trade(
+        opportunity(
+            source_quote_id=None,
+            source_book_state_id=73,
+            executable_quantity=quantity,
+        )
+    ) is False
+    assert database.logged_trade is None
 
 
 def test_paper_trader_rejects_ambiguous_market_evidence():


### PR DESCRIPTION
## Result
- carry executable top-of-book quantity through decision validation
- cap BUY and SELL paper fills to available quantity instead of rejecting the full order
- round down to database share precision and fail closed on invalid quantity

## Verification
- 59 focused tests passed
- 575 passed, 104 integration tests skipped locally without PostgreSQL
- dashboard: 60 passed, 6 integration tests skipped; production build passed
- GitHub CI runs the full PostgreSQL-backed suite