### PR TITLE
Harden day-one paper learning and execution

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -89,8 +89,8 @@ jobs:
           --release-sha "$RELEASE_SHA"
           --agent-image "$IMAGE_PREFIX/agent@$AGENT_DIGEST"
           --dashboard-image "$IMAGE_PREFIX/dashboard@$DASHBOARD_DIGEST"
-          --schema-min 45
-          --schema-max 45
+          --schema-min 46
+          --schema-max 46
           --created-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
       - name: Upload immutable release manifest

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -89,8 +89,8 @@ jobs:
           --release-sha "$RELEASE_SHA"
           --agent-image "$IMAGE_PREFIX/agent@$AGENT_DIGEST"
           --dashboard-image "$IMAGE_PREFIX/dashboard@$DASHBOARD_DIGEST"
-          --schema-min 47
-          --schema-max 47
+          --schema-min 48
+          --schema-max 48
           --created-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
       - name: Upload immutable release manifest

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -89,8 +89,8 @@ jobs:
           --release-sha "$RELEASE_SHA"
           --agent-image "$IMAGE_PREFIX/agent@$AGENT_DIGEST"
           --dashboard-image "$IMAGE_PREFIX/dashboard@$DASHBOARD_DIGEST"
-          --schema-min 46
-          --schema-max 46
+          --schema-min 47
+          --schema-max 47
           --created-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
       - name: Upload immutable release manifest

--- a/README.md
+++ b/README.md
@@ -218,6 +218,13 @@ stängda affärer och kritiska incidenter räknas från append-only-loggar
 och drawdown använder sessionens högsta/lägsta NAV. Se
 [forward-paper-kontraktet](docs/forward-paper-benchmark.md).
 
+Schema 48 ger även vanlig papertrading en separat, versionsbunden
+kostnadspolicy. Fills från förseglad orderbok använder faktisk spread,
+5 baspunkters konservativ slippage och 0,25 procents courtage med minst
+1 SEK. Policyn gäller endast framåt och ersätter aldrig ett aktivt
+benchmarks frysta modell. Se
+[ADR-004](docs/decisions/ADR-004-default-paper-execution-costs.md).
+
 Schema 16 gör även den löpande portföljvärderingen spårbar. Öppna
 positioner får endast värderas med quotes från den aktuella,
 fullvaliderade leverantören. Varje sparad snapshot binder ticker, antal,

--- a/STATE.md
+++ b/STATE.md
@@ -264,6 +264,10 @@ blockerade.
   slippagemodellen för exekveringspris, kassaflöde och netto-FIFO-P&L.
   Stängda positioner hämtas från ledgern och kritiska incidenter från
   en separat append-only incidentlogg.
+- Schema 48 binder vanliga orderboksbaserade paperfills till en separat
+  policy med faktisk spread, 5 baspunkters slippage och 0,25 procents
+  courtage med minst 1 SEK. Policyn är framåtriktad och påverkar inte
+  ett aktivt benchmarks frysta modell.
 - Varje benchmark-affär binds till ett exakt `market_quotes`-ID och
   stoppas vid fel aktie, provider eller pris, för gammal eller framtida
   offert samt exekvering utanför en öppen XSTO-session.

--- a/agent/src/core/analyzer.py
+++ b/agent/src/core/analyzer.py
@@ -308,11 +308,18 @@ class MarketAnalyzer:
             'Basic Materials': 15,
             'Technology': 17,
             'Consumer Cyclical': 12,
+            'Consumer Discretionary': 12,
             'Consumer Defensive': 14,
+            'Consumer Staples': 14,
             'Financial Services': 15,
+            'Financials': 15,
             'Healthcare': 17,
+            'Health Care': 17,
             'Communication Services': 12,
+            'Telecommunications': 12,
             'Real Estate': 10,
+            'Energy': 15,
+            'Utilities': 14,
         }
         sector_score = sector_scores.get(sector, 12)
         

--- a/agent/src/core/brain.py
+++ b/agent/src/core/brain.py
@@ -652,7 +652,7 @@ class TradingBrain:
             ("PROSPECTS", self._get_prospects_context()),
             ("RAPPORTER (5 dagar)", self._get_reports_context()),
         ]
-        if deep:
+        if deep and candidate_snapshot is None:
             sections.append(("ALLA PRISER", self._get_prices_context()))
 
         parts = []

--- a/agent/src/core/execution_costs.py
+++ b/agent/src/core/execution_costs.py
@@ -1,4 +1,4 @@
-"""Deterministic paper-fill costs for a frozen benchmark experiment."""
+"""Deterministic paper-fill costs for paper trading and benchmarks."""
 
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
@@ -15,6 +15,7 @@ class ExecutionCostModel:
     fee_bps: Decimal
     spread_bps: Decimal
     slippage_bps: Decimal
+    minimum_fee: Decimal = Decimal("0")
 
     def __post_init__(self) -> None:
         for name in ("fee_bps", "spread_bps", "slippage_bps"):
@@ -24,6 +25,10 @@ class ExecutionCostModel:
                     f"{name} must be between 0 and 1000"
                 )
             object.__setattr__(self, name, value)
+        minimum_fee = _finite_decimal(self.minimum_fee, "minimum_fee")
+        if not Decimal("0") <= minimum_fee <= Decimal("10000"):
+            raise ValueError("minimum_fee must be between 0 and 10000")
+        object.__setattr__(self, "minimum_fee", minimum_fee)
 
     @classmethod
     def zero(cls) -> "ExecutionCostModel":
@@ -31,6 +36,16 @@ class ExecutionCostModel:
             fee_bps=Decimal("0"),
             spread_bps=Decimal("0"),
             slippage_bps=Decimal("0"),
+        )
+
+    @classmethod
+    def swedish_retail(cls) -> "ExecutionCostModel":
+        """Default paper model: retail fee, actual book spread, slippage."""
+        return cls(
+            fee_bps=Decimal("25"),
+            spread_bps=Decimal("0"),
+            slippage_bps=Decimal("5"),
+            minimum_fee=Decimal("1"),
         )
 
 
@@ -75,9 +90,15 @@ def calculate_paper_execution(
         _MONEY_QUANTUM,
         rounding=ROUND_HALF_UP,
     )
-    fee_amount = (gross_value * costs.fee_bps / _BPS).quantize(
-        _MONEY_QUANTUM,
-        rounding=ROUND_HALF_UP,
+    fee_amount = max(
+        (gross_value * costs.fee_bps / _BPS).quantize(
+            _MONEY_QUANTUM,
+            rounding=ROUND_HALF_UP,
+        ),
+        costs.minimum_fee.quantize(
+            _MONEY_QUANTUM,
+            rounding=ROUND_HALF_UP,
+        ),
     )
     spread_cost = (
         quote * quantity * half_spread_bps / _BPS
@@ -151,9 +172,15 @@ def calculate_top_of_book_execution(
         _MONEY_QUANTUM,
         rounding=ROUND_HALF_UP,
     )
-    fee_amount = (gross_value * costs.fee_bps / _BPS).quantize(
-        _MONEY_QUANTUM,
-        rounding=ROUND_HALF_UP,
+    fee_amount = max(
+        (gross_value * costs.fee_bps / _BPS).quantize(
+            _MONEY_QUANTUM,
+            rounding=ROUND_HALF_UP,
+        ),
+        costs.minimum_fee.quantize(
+            _MONEY_QUANTUM,
+            rounding=ROUND_HALF_UP,
+        ),
     )
     spread_cost = (
         abs(executable_side - midpoint) * quantity

--- a/agent/src/core/schedule.py
+++ b/agent/src/core/schedule.py
@@ -74,6 +74,29 @@ def provider_routine_grace_periods(
     return {"open": max(_GRACE_PERIOD, provider_window)}
 
 
+def provider_routine_start_delays(
+    market_data_mode: Mapping[str, object],
+) -> dict[str, timedelta]:
+    """Delay open work until the provider can expose its first book."""
+    if not isinstance(market_data_mode, Mapping):
+        raise ValueError("market_data_mode must be a mapping")
+    if market_data_mode.get("data_type") != "delayed-pre-trade-equity":
+        return {}
+    nominal_delay = market_data_mode.get("nominal_delay_seconds")
+    if (
+        isinstance(nominal_delay, bool)
+        or not isinstance(nominal_delay, int)
+        or not 0 <= nominal_delay <= 24 * 60 * 60
+    ):
+        raise ValueError(
+            "nominal_delay_seconds must be a non-negative int"
+        )
+    return {
+        "open": timedelta(seconds=nominal_delay)
+        + _PROVIDER_PROCESSING_ALLOWANCE
+    }
+
+
 def _routine_grace_period(
     name: str,
     grace_periods: Mapping[str, timedelta] | None,
@@ -85,6 +108,21 @@ def _routine_grace_period(
         days=1
     ):
         raise ValueError("routine grace period must be between 20 minutes and 1 day")
+    return value
+
+
+def _routine_start_delay(
+    name: str,
+    start_delays: Mapping[str, timedelta] | None,
+) -> timedelta:
+    if start_delays is None or name not in start_delays:
+        return timedelta(0)
+    value = start_delays[name]
+    if (
+        not isinstance(value, timedelta)
+        or not timedelta(0) <= value <= timedelta(days=1)
+    ):
+        raise ValueError("routine start delay must be between 0 and 1 day")
     return value
 
 
@@ -131,6 +169,7 @@ def due_routines(
     *,
     completed: AbstractSet[str],
     grace_periods: Mapping[str, timedelta] | None = None,
+    start_delays: Mapping[str, timedelta] | None = None,
 ) -> list[DueRoutine]:
     """Return routines due within a bounded local-time grace window."""
     local_now = stockholm_now(now)
@@ -143,10 +182,9 @@ def due_routines(
         )
         delay = local_now - scheduled_at
         routine = DueRoutine(name=name, scheduled_at=scheduled_at)
-        if timedelta(0) <= delay <= _routine_grace_period(
-            name,
-            grace_periods,
-        ):
+        starts_at = _routine_start_delay(name, start_delays)
+        expires_at = _routine_grace_period(name, grace_periods)
+        if starts_at <= delay <= expires_at:
             if routine.key not in completed:
                 result.append(routine)
     return result

--- a/agent/src/data/database.py
+++ b/agent/src/data/database.py
@@ -54,6 +54,7 @@ from .nasdaq_reference import (
     NasdaqAliasSyncResult,
     NasdaqInstrumentAlias,
 )
+from .nasdaq_sector import SectorClassification
 from .top_of_book import (
     TopOfBookSnapshot,
     TopOfBookState,
@@ -1410,6 +1411,82 @@ class Database:
                     "XSTO company mapping is incomplete after ISIN fallback"
                 )
             return int(mapped_count)
+
+    def get_active_xsto_company_isins(self) -> tuple[str, ...]:
+        """Return stable identifiers for active mapped XSTO companies."""
+        with self.Session() as session:
+            rows = session.execute(text("""
+                SELECT instrument.isin
+                FROM companies company
+                JOIN instruments instrument
+                  ON instrument.id = company.instrument_id
+                WHERE instrument.mic = 'XSTO'
+                  AND instrument.status = 'ACTIVE'
+                ORDER BY instrument.isin
+            """)).mappings().all()
+        return tuple(row["isin"].strip().upper() for row in rows)
+
+    def update_company_sectors(
+        self,
+        classifications: Mapping[str, SectorClassification],
+        *,
+        source: str,
+        verified_at: datetime,
+    ) -> int:
+        """Apply exact-ISIN sectors without replacing curated classifications."""
+        if (
+            not isinstance(source, str)
+            or not re.fullmatch(r"[a-z0-9][a-z0-9._-]{1,99}", source)
+        ):
+            raise MarketDataError("sector source is invalid")
+        if (
+            not isinstance(verified_at, datetime)
+            or verified_at.tzinfo is None
+            or verified_at.utcoffset() is None
+        ):
+            raise MarketDataError("sector verified_at must be timezone-aware")
+        if not isinstance(classifications, Mapping) or not classifications:
+            raise MarketDataError("sector classifications are empty")
+        if len(classifications) > 2000:
+            raise MarketDataError("sector classifications are too large")
+
+        updated = 0
+        with self.Session.begin() as session:
+            for isin, classification in classifications.items():
+                if (
+                    not isinstance(classification, SectorClassification)
+                    or isin != classification.isin
+                    or not re.fullmatch(r"[A-Z]{2}[A-Z0-9]{9}[0-9]", isin)
+                ):
+                    raise MarketDataError(
+                        "sector classification identity is invalid"
+                    )
+                result = session.execute(text("""
+                    UPDATE companies company
+                    SET
+                        sector = :sector,
+                        sector_source = :source,
+                        sector_verified_at = :verified_at,
+                        updated_at = NOW()
+                    FROM instruments instrument
+                    WHERE instrument.id = company.instrument_id
+                      AND instrument.isin = :isin
+                      AND instrument.mic = 'XSTO'
+                      AND instrument.status = 'ACTIVE'
+                      AND (
+                          company.sector IS NULL
+                          OR BTRIM(company.sector) = ''
+                          OR company.sector = 'Unclassified'
+                          OR company.sector_source = :source
+                      )
+                """), {
+                    "isin": isin,
+                    "sector": classification.sector,
+                    "source": source,
+                    "verified_at": verified_at,
+                })
+                updated += max(0, int(result.rowcount or 0))
+        return updated
 
     def ensure_public_pretrade_contract(
         self,

--- a/agent/src/data/database.py
+++ b/agent/src/data/database.py
@@ -317,10 +317,10 @@ class Database:
             version = session.execute(
                 text("SELECT COALESCE(MAX(version), 0) FROM schema_migrations")
             ).scalar_one()
-            if version < 45:
+            if version < 47:
                 raise RuntimeError(
                     f"Database schema is too old (version {version}); "
-                    "version 45 is required"
+                    "version 47 is required"
                 )
 
     def upsert_instruments(
@@ -6757,7 +6757,7 @@ class Database:
                     SELECT
                         prediction.id AS prediction_id,
                         DATE_TRUNC('minute', prediction.observed_at)
-                            AS entry_event_time,
+                            AS requested_entry_event_time,
                         prediction_state.instrument_id,
                         prediction_batch.provider_contract_id
                     FROM candidate_predictions prediction
@@ -6775,26 +6775,42 @@ class Database:
                 evidence AS (
                     SELECT
                         due.*,
-                        state.id AS entry_state_id,
-                        (state.bid_price + state.ask_price) / 2
-                            AS entry_price
+                        candidate.entry_event_time,
+                        candidate.entry_state_id,
+                        candidate.entry_price
                     FROM due
-                    JOIN pre_trade_batches batch
-                      ON batch.provider_contract_id =
-                            due.provider_contract_id
-                     AND batch.report_minute = due.entry_event_time
-                    JOIN pre_trade_stream_cursors seal
-                      ON seal.batch_id = batch.id
-                    JOIN pre_trade_book_states state
-                      ON state.batch_id = batch.id
-                     AND state.instrument_id = due.instrument_id
-                    WHERE state.bid_price IS NOT NULL
-                      AND state.ask_price IS NOT NULL
-                      AND state.bid_quantity > 0
-                      AND state.ask_quantity > 0
-                      AND state.trading_system = 'CLOB'
-                      AND state.trading_phase = 'COTR'
-                      AND state.received_at <= :evaluated_at
+                    JOIN LATERAL (
+                        SELECT
+                            batch.report_minute AS entry_event_time,
+                            state.id AS entry_state_id,
+                            (state.bid_price + state.ask_price) / 2
+                                AS entry_price
+                        FROM pre_trade_batches batch
+                        JOIN pre_trade_stream_cursors seal
+                          ON seal.batch_id = batch.id
+                        JOIN pre_trade_book_states state
+                          ON state.batch_id = batch.id
+                         AND state.instrument_id = due.instrument_id
+                        WHERE batch.provider_contract_id =
+                                due.provider_contract_id
+                          AND batch.report_minute >=
+                                due.requested_entry_event_time
+                          AND batch.report_minute <=
+                                due.requested_entry_event_time
+                                + INTERVAL '2 minutes'
+                          AND state.bid_price IS NOT NULL
+                          AND state.ask_price IS NOT NULL
+                          AND state.bid_quantity > 0
+                          AND state.ask_quantity > 0
+                          AND state.trading_system = 'CLOB'
+                          AND state.trading_phase = 'COTR'
+                          AND state.received_at <= :evaluated_at
+                        ORDER BY
+                            batch.report_minute,
+                            batch.id,
+                            state.id
+                        LIMIT 1
+                    ) candidate ON TRUE
                 )
                 INSERT INTO candidate_prediction_entries (
                     prediction_id,
@@ -6850,26 +6866,42 @@ class Database:
                 evidence AS (
                     SELECT
                         due.*,
-                        state.id AS outcome_state_id,
-                        (state.bid_price + state.ask_price) / 2
-                            AS observed_price
+                        candidate.actual_target_event_time,
+                        candidate.outcome_state_id,
+                        candidate.observed_price
                     FROM due
-                    JOIN pre_trade_batches batch
-                      ON batch.provider_contract_id =
-                            due.provider_contract_id
-                     AND batch.report_minute = due.target_event_time
-                    JOIN pre_trade_stream_cursors seal
-                      ON seal.batch_id = batch.id
-                    JOIN pre_trade_book_states state
-                      ON state.batch_id = batch.id
-                     AND state.instrument_id = due.instrument_id
-                    WHERE state.bid_price IS NOT NULL
-                      AND state.ask_price IS NOT NULL
-                      AND state.bid_quantity > 0
-                      AND state.ask_quantity > 0
-                      AND state.trading_system = 'CLOB'
-                      AND state.trading_phase = 'COTR'
-                      AND state.received_at <= :evaluated_at
+                    JOIN LATERAL (
+                        SELECT
+                            batch.report_minute
+                                AS actual_target_event_time,
+                            state.id AS outcome_state_id,
+                            (state.bid_price + state.ask_price) / 2
+                                AS observed_price
+                        FROM pre_trade_batches batch
+                        JOIN pre_trade_stream_cursors seal
+                          ON seal.batch_id = batch.id
+                        JOIN pre_trade_book_states state
+                          ON state.batch_id = batch.id
+                         AND state.instrument_id = due.instrument_id
+                        WHERE batch.provider_contract_id =
+                                due.provider_contract_id
+                          AND batch.report_minute >= due.target_event_time
+                          AND batch.report_minute <=
+                                due.target_event_time
+                                + INTERVAL '2 minutes'
+                          AND state.bid_price IS NOT NULL
+                          AND state.ask_price IS NOT NULL
+                          AND state.bid_quantity > 0
+                          AND state.ask_quantity > 0
+                          AND state.trading_system = 'CLOB'
+                          AND state.trading_phase = 'COTR'
+                          AND state.received_at <= :evaluated_at
+                        ORDER BY
+                            batch.report_minute,
+                            batch.id,
+                            state.id
+                        LIMIT 1
+                    ) candidate ON TRUE
                 ),
                 inserted AS (
                     INSERT INTO candidate_prediction_outcomes (
@@ -6886,7 +6918,7 @@ class Database:
                         evidence.prediction_id,
                         evidence.entry_id,
                         evidence.horizon,
-                        evidence.target_event_time,
+                        evidence.actual_target_event_time,
                         :evaluated_at,
                         evidence.outcome_state_id,
                         evidence.observed_price,

--- a/agent/src/data/database.py
+++ b/agent/src/data/database.py
@@ -317,10 +317,10 @@ class Database:
             version = session.execute(
                 text("SELECT COALESCE(MAX(version), 0) FROM schema_migrations")
             ).scalar_one()
-            if version < 47:
+            if version < 48:
                 raise RuntimeError(
                     f"Database schema is too old (version {version}); "
-                    "version 47 is required"
+                    "version 48 is required"
                 )
 
     def upsert_instruments(
@@ -9336,9 +9336,11 @@ class Database:
                         "source_book_state_id is required by the running "
                         "benchmark execution contract"
                     )
-            if (
-                benchmark is not None
-                and benchmark['execution_price_source']
+            if benchmark is None and source_book is not None:
+                cost_model = ExecutionCostModel.swedish_retail()
+            if source_book is not None and (
+                benchmark is None
+                or benchmark['execution_price_source']
                 == 'TOP_OF_BOOK_PLUS_SLIPPAGE'
             ):
                 execution = calculate_top_of_book_execution(
@@ -9565,6 +9567,27 @@ class Database:
                     None,
                 )
 
+            insert_trade = dict(normalized)
+            if source_book is not None:
+                raw_side_price = Decimal(
+                    source_book[
+                        'ask_price'
+                        if normalized['action'] == 'BUY'
+                        else 'bid_price'
+                    ]
+                ).quantize(Decimal('0.00000001'))
+                insert_trade.update({
+                    'quote_price': None,
+                    'price': raw_side_price,
+                    'total_value': (
+                        raw_side_price * normalized['shares']
+                    ).quantize(Decimal('0.01')),
+                    'fee_amount': None,
+                    'spread_cost': None,
+                    'slippage_cost': None,
+                    'net_cash_effect': None,
+                })
+
             result = session.execute(text("""
                 INSERT INTO trades (
                     ticker, action, shares, quote_price, price, total_value,
@@ -9592,7 +9615,7 @@ class Database:
                 )
                 RETURNING id, executed_at
             """), {
-                **normalized,
+                **insert_trade,
                 'entry_trade_id': entry_trade_id,
                 'pnl': realized_pnl,
                 'closes_position': closes_position,

--- a/agent/src/data/nasdaq_sector.py
+++ b/agent/src/data/nasdaq_sector.py
@@ -1,0 +1,226 @@
+"""Validated public Nasdaq sector classifications for XSTO companies."""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import re
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from .market_data import MarketDataError
+
+
+_ENDPOINT = "https://api.nasdaq.com/api/nordic/screener/shares"
+_SOURCE = "nasdaq-public-screener-xsto"
+_TIMEOUT = (5.0, 30.0)
+_MAX_RESPONSE_BYTES = 5_000_000
+_CHUNK_BYTES = 64 * 1024
+_ISIN_PATTERN = re.compile(r"^[A-Z]{2}[A-Z0-9]{9}[0-9]$")
+_SECTORS = frozenset(
+    {
+        "Basic Materials",
+        "Consumer Discretionary",
+        "Consumer Staples",
+        "Energy",
+        "Financials",
+        "Health Care",
+        "Industrials",
+        "Real Estate",
+        "Technology",
+        "Telecommunications",
+        "Utilities",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SectorClassification:
+    isin: str
+    sector: str
+    company_name: str
+    symbol: str
+
+
+@dataclass(frozen=True)
+class SectorSyncResult:
+    active_instruments: int
+    matched_instruments: int
+    updated_companies: int
+    coverage: float
+    verified_at: datetime
+
+
+class NasdaqSectorClient:
+    """Fetch one bounded, validated Stockholm sector snapshot."""
+
+    def __init__(self, *, session: requests.Session | None = None):
+        self._session = session or build_nasdaq_sector_session()
+
+    def fetch(self) -> dict[str, SectorClassification]:
+        response = self._session.get(
+            _ENDPOINT,
+            params={
+                "category": "MAIN_MARKET",
+                "tableonly": "false",
+                "market": "STO",
+            },
+            timeout=_TIMEOUT,
+            allow_redirects=False,
+            stream=True,
+        )
+        try:
+            response.raise_for_status()
+            payload = _bounded_response(response)
+        except requests.RequestException as exc:
+            raise MarketDataError("Nasdaq sector request failed") from exc
+        finally:
+            response.close()
+        return parse_nasdaq_sector_payload(payload)
+
+
+class NasdaqSectorSyncService:
+    """Apply classifications only when exact-ISIN coverage is sufficient."""
+
+    def __init__(
+        self,
+        *,
+        database,
+        client: NasdaqSectorClient | None = None,
+        clock: Callable[[], datetime] | None = None,
+        minimum_coverage: float = 0.95,
+    ):
+        if not 0 < minimum_coverage <= 1:
+            raise ValueError("minimum_coverage must be between zero and one")
+        self._database = database
+        self._client = client or NasdaqSectorClient()
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._minimum_coverage = minimum_coverage
+
+    def sync(self) -> SectorSyncResult:
+        verified_at = self._clock()
+        if verified_at.tzinfo is None or verified_at.utcoffset() is None:
+            raise MarketDataError("sector sync clock must be timezone-aware")
+        active_isins = tuple(self._database.get_active_xsto_company_isins())
+        if not active_isins:
+            raise MarketDataError("active XSTO company universe is empty")
+        classifications = self._client.fetch()
+        matched = {
+            isin: classifications[isin]
+            for isin in active_isins
+            if isin in classifications
+        }
+        coverage = len(matched) / len(active_isins)
+        if coverage < self._minimum_coverage:
+            raise MarketDataError(
+                "Nasdaq sector coverage is below the required threshold"
+            )
+        updated = self._database.update_company_sectors(
+            matched,
+            source=_SOURCE,
+            verified_at=verified_at,
+        )
+        return SectorSyncResult(
+            active_instruments=len(active_isins),
+            matched_instruments=len(matched),
+            updated_companies=updated,
+            coverage=coverage,
+            verified_at=verified_at,
+        )
+
+
+def parse_nasdaq_sector_payload(
+    payload: bytes,
+) -> dict[str, SectorClassification]:
+    try:
+        document = json.loads(payload)
+        if document["status"]["rCode"] != 200:
+            raise KeyError("provider status")
+        rows = document["data"]["instrumentListing"]["rows"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise MarketDataError("Nasdaq sector payload schema is invalid") from exc
+    if not isinstance(rows, list) or len(rows) > 2000:
+        raise MarketDataError("Nasdaq sector payload rows are invalid")
+
+    result: dict[str, SectorClassification] = {}
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise MarketDataError("Nasdaq sector row is invalid")
+        isin = _required_text(row.get("isin"), "ISIN", 12).upper()
+        sector = _required_text(row.get("sector"), "sector", 50)
+        company_name = _required_text(
+            row.get("fullName"), "company name", 300
+        )
+        symbol = _required_text(row.get("symbol"), "symbol", 50)
+        if not _ISIN_PATTERN.fullmatch(isin):
+            raise MarketDataError("Nasdaq sector ISIN is invalid")
+        if sector not in _SECTORS:
+            raise MarketDataError("Nasdaq sector is unsupported")
+        classification = SectorClassification(
+            isin=isin,
+            sector=sector,
+            company_name=company_name,
+            symbol=symbol,
+        )
+        previous = result.get(isin)
+        if previous is not None and previous != classification:
+            raise MarketDataError("Nasdaq sector ISIN is duplicated")
+        result[isin] = classification
+    return result
+
+
+def build_nasdaq_sector_session() -> requests.Session:
+    retry = Retry(
+        total=1,
+        connect=1,
+        read=1,
+        status=1,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset({"GET"}),
+        backoff_factor=0.5,
+        respect_retry_after_header=True,
+    )
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Accept": "application/json",
+            "User-Agent": "TradingAgent/sector-sync-1.0",
+        }
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retry))
+    return session
+
+
+def _bounded_response(response) -> bytes:
+    length = response.headers.get("Content-Length")
+    if length is not None:
+        try:
+            if int(length) > _MAX_RESPONSE_BYTES:
+                raise MarketDataError("Nasdaq sector response is too large")
+        except ValueError as exc:
+            raise MarketDataError(
+                "Nasdaq sector Content-Length is invalid"
+            ) from exc
+    chunks = []
+    total = 0
+    for chunk in response.iter_content(_CHUNK_BYTES):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > _MAX_RESPONSE_BYTES:
+            raise MarketDataError("Nasdaq sector response is too large")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _required_text(value: object, field: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise MarketDataError(f"Nasdaq sector {field} is required")
+    cleaned = value.strip()
+    if not cleaned or len(cleaned) > maximum or any(
+        ord(char) < 32 for char in cleaned
+    ):
+        raise MarketDataError(f"Nasdaq sector {field} is invalid")
+    return cleaned

--- a/agent/src/main.py
+++ b/agent/src/main.py
@@ -38,6 +38,7 @@ from .core.schedule import (
     brain_cycle_slot,
     due_routines,
     provider_routine_grace_periods,
+    provider_routine_start_delays,
     recoverable_routines,
     recovery_slots,
     stockholm_now,
@@ -163,16 +164,22 @@ def run_daemon(db, analyzer, trader, brain=None, student=None):
 
             if schedule_evidence_ready:
                 try:
+                    market_data_mode = db.get_authorized_market_data_mode(now)
                     grace_periods = provider_routine_grace_periods(
-                        db.get_authorized_market_data_mode(now)
+                        market_data_mode
+                    )
+                    start_delays = provider_routine_start_delays(
+                        market_data_mode
                     )
                 except Exception:
                     grace_periods = {}
+                    start_delays = {}
                 if grace_periods:
                     current_routines = due_routines(
                         now,
                         completed=completed_routines,
                         grace_periods=grace_periods,
+                        start_delays=start_delays,
                     )
                 else:
                     current_routines = due_routines(

--- a/agent/src/sector_sync.py
+++ b/agent/src/sector_sync.py
@@ -1,0 +1,112 @@
+"""Opt-in daemon for public Nasdaq XSTO sector classifications."""
+
+from collections.abc import Callable, Mapping
+import logging
+import os
+import sys
+import time
+
+from src.data.database import Database
+from src.data.market_data import MarketDataError
+from src.data.nasdaq_sector import NasdaqSectorClient, NasdaqSectorSyncService
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_sector_sync_service(
+    *,
+    database,
+    environ: Mapping[str, str] | None = None,
+    client: NasdaqSectorClient | None = None,
+    clock=None,
+) -> NasdaqSectorSyncService:
+    environ = os.environ if environ is None else environ
+    if environ.get("ENABLE_NASDAQ_SECTOR_SYNC", "").lower() != "true":
+        raise MarketDataError(
+            "Nasdaq sector sync is disabled; set "
+            "ENABLE_NASDAQ_SECTOR_SYNC=true explicitly"
+        )
+    try:
+        minimum_coverage = float(
+            environ.get("NASDAQ_SECTOR_MINIMUM_COVERAGE", "0.95")
+        )
+    except ValueError as exc:
+        raise MarketDataError(
+            "NASDAQ_SECTOR_MINIMUM_COVERAGE must be a decimal"
+        ) from exc
+    if not 0.90 <= minimum_coverage <= 1:
+        raise MarketDataError(
+            "minimum sector coverage must be between 0.90 and 1"
+        )
+    return NasdaqSectorSyncService(
+        database=database,
+        client=client,
+        clock=clock,
+        minimum_coverage=minimum_coverage,
+    )
+
+
+def run_daemon(
+    *,
+    service: NasdaqSectorSyncService,
+    interval_seconds: int,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> None:
+    if not 21600 <= interval_seconds <= 604800:
+        raise MarketDataError(
+            "SECTOR_SYNC_INTERVAL_SECONDS must be between 21600 and 604800"
+        )
+    while True:
+        try:
+            result = service.sync()
+            logger.info(
+                "sector_sync_complete active=%s matched=%s updated=%s "
+                "coverage=%.4f verified_at=%s",
+                result.active_instruments,
+                result.matched_instruments,
+                result.updated_companies,
+                result.coverage,
+                result.verified_at.isoformat(),
+            )
+        except KeyboardInterrupt:
+            logger.info("sector_sync_shutdown")
+            return
+        except Exception:
+            logger.exception("sector_sync_failed")
+        sleeper(interval_seconds)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    try:
+        service = build_sector_sync_service(database=Database())
+    except (MarketDataError, RuntimeError) as exc:
+        logger.error("sector_sync_configuration_failed error=%s", exc)
+        raise SystemExit(1) from None
+
+    mode = sys.argv[1] if len(sys.argv) > 1 else "daemon"
+    if mode == "once":
+        try:
+            result = service.sync()
+        except (MarketDataError, RuntimeError) as exc:
+            logger.error("sector_sync_failed error=%s", exc)
+            raise SystemExit(1) from None
+        logger.info("sector_sync_once_complete result=%s", result)
+        return
+    if mode != "daemon":
+        raise SystemExit("Usage: python -m src.sector_sync [once|daemon]")
+
+    try:
+        interval = int(os.getenv("SECTOR_SYNC_INTERVAL_SECONDS", "86400"))
+        run_daemon(service=service, interval_seconds=interval)
+    except (MarketDataError, ValueError) as exc:
+        logger.error("sector_sync_configuration_failed error=%s", exc)
+        raise SystemExit(1) from None
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/tests/test_authoritative_runtime_data.py
+++ b/agent/tests/test_authoritative_runtime_data.py
@@ -127,6 +127,25 @@ def test_brain_describes_public_pretrade_breadth_without_requiring_index():
     assert "OMXSGI krävs inte" in context
 
 
+def test_deep_candidate_context_does_not_repeat_the_full_price_universe():
+    brain = TradingBrain.__new__(TradingBrain)
+    brain._get_portfolio_context = lambda: "portfolio"
+    brain._get_macro_context = lambda: "macro"
+    brain._get_news_context = lambda: "news"
+    brain._get_prospects_context = lambda: "prospects"
+    brain._get_reports_context = lambda: "reports"
+    brain._get_prices_context = lambda: (_ for _ in ()).throw(
+        AssertionError("candidate context must not duplicate all prices")
+    )
+
+    context = brain.build_context(
+        deep=True,
+        candidate_snapshot=[],
+    )
+
+    assert "ALLA PRISER" not in context
+
+
 def test_missing_macro_evidence_contributes_no_opportunity_points():
     analyzer = MarketAnalyzer(AnalyzerDatabase())
 

--- a/agent/tests/test_authoritative_runtime_data.py
+++ b/agent/tests/test_authoritative_runtime_data.py
@@ -141,6 +141,20 @@ def test_missing_macro_evidence_contributes_no_opportunity_points():
     assert score["macro"] == 0
 
 
+def test_nasdaq_sector_names_contribute_expected_opportunity_points():
+    analyzer = MarketAnalyzer(AnalyzerDatabase())
+
+    score = analyzer._calculate_opportunity_score(
+        "ISOFOL",
+        {"sector": "Health Care"},
+        {"net_sentiment": 0, "impacts": []},
+        {"change_pct": 0},
+        None,
+    )
+
+    assert score["sector"] == 17
+
+
 def test_analyzer_builds_prospects_from_multi_horizon_pretrade_evidence():
     from decimal import Decimal
 

--- a/agent/tests/test_database_integration.py
+++ b/agent/tests/test_database_integration.py
@@ -5348,7 +5348,12 @@ def test_paper_fill_is_bound_to_the_executable_book_side(
                 source_book_state_id,
                 source_quote_id,
                 quote_price,
-                price
+                price,
+                fee_amount,
+                spread_cost,
+                slippage_cost,
+                net_cash_effect,
+                paper_execution_cost_policy_id
             FROM trades
             WHERE id = %s
             """,
@@ -5357,8 +5362,13 @@ def test_paper_fill_is_bound_to_the_executable_book_side(
         row = cursor.fetchone()
     assert row[0] == state_id
     assert row[1] is None
-    assert Decimal(row[2]) == Decimal("321.30000000")
-    assert Decimal(row[3]) == Decimal("321.30000000")
+    assert Decimal(row[2]) == Decimal("321.20000000")
+    assert Decimal(row[3]) == Decimal("321.46065000")
+    assert Decimal(row[4]) == Decimal("1.00")
+    assert Decimal(row[5]) == Decimal("0.10")
+    assert Decimal(row[6]) == Decimal("0.16")
+    assert Decimal(row[7]) == Decimal("322.46")
+    assert row[8] is not None
 
     with connection.cursor() as cursor:
         cursor.execute("DELETE FROM market_sessions")

--- a/agent/tests/test_database_integration.py
+++ b/agent/tests/test_database_integration.py
@@ -106,6 +106,7 @@ def _pretrade_batch(
     bid_price: str = "321.10",
     ask_quantity: str = "800",
     empty_xsto: bool = False,
+    trading_phase: str = "COTR",
 ):
     reference = reference or _pretrade_reference()
     received_at = received_at or report_minute + timedelta(minutes=15)
@@ -126,11 +127,11 @@ def _pretrade_batch(
         rows = [
             (
                 f"{event_time};SE0000115446;BUY;;{bid_price};SEK;1;"
-                f"1000;SEK;4;XSTO;CLOB;COTR;{event_time}"
+                f"1000;SEK;4;XSTO;CLOB;{trading_phase};{event_time}"
             ),
             (
                 f"{ask_time};SE0000115446;SELL;;321.30;SEK;1;"
-                f"{ask_quantity};SEK;3;XSTO;CLOB;COTR;{ask_time}"
+                f"{ask_quantity};SEK;3;XSTO;CLOB;{trading_phase};{ask_time}"
             ),
         ]
     content = (
@@ -5562,13 +5563,14 @@ def test_continuous_candidate_journal_labels_forward_outcomes(
     assert first_ids == replayed_ids
     assert len(first_ids) == 1
 
-    for index in range(61, 106):
+    for index in range(61, 108):
         report_minute = first_report_minute + timedelta(minutes=index)
         bid_price = Decimal("320.00") + Decimal("0.01") * index
         batch = _pretrade_batch(
             report_minute=report_minute,
             received_at=report_minute + timedelta(minutes=15),
             bid_price=f"{bid_price:.2f}",
+            trading_phase="HALT" if index in {75, 106} else "COTR",
         )
         snapshot = apply_top_of_book_batch(
             previous=previous,
@@ -5584,7 +5586,7 @@ def test_continuous_candidate_journal_labels_forward_outcomes(
 
     evaluated_at = (
         first_report_minute
-        + timedelta(minutes=105)
+        + timedelta(minutes=107)
         + timedelta(minutes=15, seconds=10)
     )
     inserted = db.record_candidate_prediction_outcomes(
@@ -5660,9 +5662,9 @@ def test_continuous_candidate_journal_labels_forward_outcomes(
             (first_ids[0],),
         )
         entry_event_time, entry_price, target_event_time = cursor.fetchone()
-        assert entry_event_time == first_report_minute + timedelta(minutes=75)
-        assert entry_price == Decimal("321.025")
-        assert target_event_time == first_report_minute + timedelta(minutes=105)
+        assert entry_event_time == first_report_minute + timedelta(minutes=76)
+        assert entry_price == Decimal("321.03000000")
+        assert target_event_time == first_report_minute + timedelta(minutes=107)
 
         with pytest.raises(
             psycopg2.errors.RaiseException,

--- a/agent/tests/test_execution_costs.py
+++ b/agent/tests/test_execution_costs.py
@@ -9,6 +9,15 @@ from src.core.execution_costs import (
 )
 
 
+def test_swedish_retail_model_includes_fee_and_conservative_slippage():
+    model = ExecutionCostModel.swedish_retail()
+
+    assert model.fee_bps == Decimal("25")
+    assert model.spread_bps == Decimal("0")
+    assert model.slippage_bps == Decimal("5")
+    assert model.minimum_fee == Decimal("1")
+
+
 def test_buy_and_sell_apply_frozen_spread_slippage_and_fee_model():
     model = ExecutionCostModel(
         fee_bps=Decimal("5"),

--- a/agent/tests/test_nasdaq_sector.py
+++ b/agent/tests/test_nasdaq_sector.py
@@ -1,0 +1,194 @@
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from src.data.market_data import MarketDataError
+from src.data.nasdaq_sector import (
+    NasdaqSectorClient,
+    NasdaqSectorSyncService,
+)
+
+
+NOW = datetime(2026, 8, 11, 17, 30, tzinfo=timezone.utc)
+
+
+def _payload(rows):
+    return json.dumps(
+        {
+            "data": {"instrumentListing": {"rows": rows}},
+            "status": {"rCode": 200},
+        }
+    ).encode("utf-8")
+
+
+class _Response:
+    def __init__(self, content):
+        self.content = content
+        self.headers = {"Content-Length": str(len(content))}
+        self.status_code = 200
+        self.closed = False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size):
+        assert chunk_size == 64 * 1024
+        yield self.content
+
+    def close(self):
+        self.closed = True
+
+
+class _Session:
+    def __init__(self, content):
+        self.response = _Response(content)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return self.response
+
+
+def test_client_reads_nasdaq_sectors_by_isin_from_fixed_endpoint():
+    session = _Session(
+        _payload(
+            [
+                {
+                    "isin": "SE0017486889",
+                    "fullName": "Atlas Copco A",
+                    "symbol": "ATCO A",
+                    "sector": "Industrials",
+                },
+                {
+                    "isin": "SE0009581051",
+                    "fullName": "Isofol Medical",
+                    "symbol": "ISOFOL",
+                    "sector": "Health Care",
+                },
+            ]
+        )
+    )
+
+    classifications = NasdaqSectorClient(session=session).fetch()
+
+    assert classifications["SE0017486889"].sector == "Industrials"
+    assert classifications["SE0009581051"].sector == "Health Care"
+    assert session.calls == [
+        (
+            "https://api.nasdaq.com/api/nordic/screener/shares",
+            {
+                "params": {
+                    "category": "MAIN_MARKET",
+                    "tableonly": "false",
+                    "market": "STO",
+                },
+                "timeout": (5.0, 30.0),
+                "allow_redirects": False,
+                "stream": True,
+            },
+        )
+    ]
+    assert session.response.closed
+
+
+@pytest.mark.parametrize(
+    "row,error",
+    [
+        (
+            {
+                "isin": "not-an-isin",
+                "fullName": "Bad",
+                "symbol": "BAD",
+                "sector": "Technology",
+            },
+            "ISIN",
+        ),
+        (
+            {
+                "isin": "SE0017486889",
+                "fullName": "Atlas Copco A",
+                "symbol": "ATCO A",
+                "sector": "Made Up Sector",
+            },
+            "sector",
+        ),
+    ],
+)
+def test_client_rejects_untrusted_provider_values(row, error):
+    with pytest.raises(MarketDataError, match=error):
+        NasdaqSectorClient(session=_Session(_payload([row]))).fetch()
+
+
+class _Database:
+    def __init__(self):
+        self.updated = None
+
+    def get_active_xsto_company_isins(self):
+        return ("SE0017486889", "SE0009581051", "SE0000825820")
+
+    def update_company_sectors(self, classifications, **metadata):
+        self.updated = (classifications, metadata)
+        return len(classifications)
+
+
+class _Client:
+    def fetch(self):
+        return NasdaqSectorClient(
+            session=_Session(
+                _payload(
+                    [
+                        {
+                            "isin": "SE0017486889",
+                            "fullName": "Atlas Copco A",
+                            "symbol": "ATCO A",
+                            "sector": "Industrials",
+                        },
+                        {
+                            "isin": "SE0009581051",
+                            "fullName": "Isofol Medical",
+                            "symbol": "ISOFOL",
+                            "sector": "Health Care",
+                        },
+                    ]
+                )
+            )
+        ).fetch()
+
+
+def test_sync_fails_closed_before_writing_when_coverage_is_too_low():
+    database = _Database()
+    service = NasdaqSectorSyncService(
+        database=database,
+        client=_Client(),
+        clock=lambda: NOW,
+        minimum_coverage=0.80,
+    )
+
+    with pytest.raises(MarketDataError, match="coverage"):
+        service.sync()
+
+    assert database.updated is None
+
+
+def test_sync_updates_only_exact_isin_matches_with_provenance():
+    database = _Database()
+    service = NasdaqSectorSyncService(
+        database=database,
+        client=_Client(),
+        clock=lambda: NOW,
+        minimum_coverage=0.60,
+    )
+
+    result = service.sync()
+
+    classifications, metadata = database.updated
+    assert set(classifications) == {"SE0017486889", "SE0009581051"}
+    assert metadata == {
+        "source": "nasdaq-public-screener-xsto",
+        "verified_at": NOW,
+    }
+    assert result.active_instruments == 3
+    assert result.matched_instruments == 2
+    assert result.updated_companies == 2
+    assert result.coverage == pytest.approx(2 / 3)

--- a/agent/tests/test_release_manifest.py
+++ b/agent/tests/test_release_manifest.py
@@ -81,8 +81,8 @@ def _values():
         "dashboard_image": (
             "ghcr.io/diffen77/trading-agent/dashboard@sha256:" + "c" * 64
         ),
-        "schema_min": 46,
-        "schema_max": 46,
+        "schema_min": 47,
+        "schema_max": 47,
         "created_at": "2026-07-29T12:00:00Z",
     }
 
@@ -261,8 +261,8 @@ def test_release_manifest_round_trip_is_strict_and_shell_safe(tmp_path):
     )
 
     assert manifest.release_sha == "a" * 40
-    assert manifest.schema_min == 46
-    assert manifest.schema_max == 46
+    assert manifest.schema_min == 47
+    assert manifest.schema_max == 47
     assert manifest.agent_image.endswith("b" * 64)
     assert manifest_path.read_text().splitlines() == [
         f"RELEASE_SHA={'a' * 40}",
@@ -274,8 +274,8 @@ def test_release_manifest_round_trip_is_strict_and_shell_safe(tmp_path):
             "DASHBOARD_IMAGE=ghcr.io/diffen77/trading-agent/"
             f"dashboard@sha256:{'c' * 64}"
         ),
-        "SCHEMA_MIN=46",
-        "SCHEMA_MAX=46",
+        "SCHEMA_MIN=47",
+        "SCHEMA_MAX=47",
         "CREATED_AT=2026-07-29T12:00:00Z",
     ]
 
@@ -356,8 +356,8 @@ def test_deployment_workflows_require_immutable_release_and_approval():
     assert "docker/setup-buildx-action@v4" in build
     assert "docker/login-action@v4" in build
     assert build.count("docker/build-push-action@v7") == 2
-    assert "--schema-min 46" in build
-    assert "--schema-max 46" in build
+    assert "--schema-min 47" in build
+    assert "--schema-max 47" in build
     assert "workflow_dispatch:" in deploy
     assert "environment: production" in deploy
     assert "concurrency:" in deploy
@@ -503,7 +503,7 @@ case "$*" in
       's#.*releases/\([0-9a-f]\{40\}\)/.*#\1#p' \
       > "$FAKE_ACTIVE_RELEASE_FILE"
     ;;
-  *" exec -T db psql "*) printf '46\n' ;;
+  *" exec -T db psql "*) printf '47\n' ;;
   *"image inspect "*"org.opencontainers.image.revision"*)
     if [ -n "$FAKE_IMAGE_REVISION" ]; then
       printf '%s\n' "$FAKE_IMAGE_REVISION"

--- a/agent/tests/test_release_manifest.py
+++ b/agent/tests/test_release_manifest.py
@@ -81,8 +81,8 @@ def _values():
         "dashboard_image": (
             "ghcr.io/diffen77/trading-agent/dashboard@sha256:" + "c" * 64
         ),
-        "schema_min": 45,
-        "schema_max": 45,
+        "schema_min": 46,
+        "schema_max": 46,
         "created_at": "2026-07-29T12:00:00Z",
     }
 
@@ -261,8 +261,8 @@ def test_release_manifest_round_trip_is_strict_and_shell_safe(tmp_path):
     )
 
     assert manifest.release_sha == "a" * 40
-    assert manifest.schema_min == 45
-    assert manifest.schema_max == 45
+    assert manifest.schema_min == 46
+    assert manifest.schema_max == 46
     assert manifest.agent_image.endswith("b" * 64)
     assert manifest_path.read_text().splitlines() == [
         f"RELEASE_SHA={'a' * 40}",
@@ -274,8 +274,8 @@ def test_release_manifest_round_trip_is_strict_and_shell_safe(tmp_path):
             "DASHBOARD_IMAGE=ghcr.io/diffen77/trading-agent/"
             f"dashboard@sha256:{'c' * 64}"
         ),
-        "SCHEMA_MIN=45",
-        "SCHEMA_MAX=45",
+        "SCHEMA_MIN=46",
+        "SCHEMA_MAX=46",
         "CREATED_AT=2026-07-29T12:00:00Z",
     ]
 
@@ -356,8 +356,8 @@ def test_deployment_workflows_require_immutable_release_and_approval():
     assert "docker/setup-buildx-action@v4" in build
     assert "docker/login-action@v4" in build
     assert build.count("docker/build-push-action@v7") == 2
-    assert "--schema-min 45" in build
-    assert "--schema-max 45" in build
+    assert "--schema-min 46" in build
+    assert "--schema-max 46" in build
     assert "workflow_dispatch:" in deploy
     assert "environment: production" in deploy
     assert "concurrency:" in deploy
@@ -388,6 +388,21 @@ def test_deployment_workflows_require_immutable_release_and_approval():
     assert 'profiles: ["object-storage"]' in compose
     assert "  nasdaq-alias-sync:" in compose
     assert 'profiles: ["nasdaq-reference"]' in compose
+    assert "  sector-sync:" in compose
+    sector_service = compose.split("  sector-sync:", 1)[1].split(
+        "\n  market-sync:",
+        1,
+    )[0]
+    assert 'profiles: ["market-data"]' in sector_service
+    assert (
+        'command: ["python", "-m", "src.sector_sync", "daemon"]'
+        in sector_service
+    )
+    assert "DATABASE_URL_FILE: /run/secrets/database_url" in sector_service
+    assert (
+        "ENABLE_NASDAQ_SECTOR_SYNC: "
+        "${ENABLE_NASDAQ_SECTOR_SYNC:-true}"
+    ) in sector_service
     assert "  monitor:" in local_compose
     assert "  learning-worker:" in local_compose
     assert "  knowledge-worker:" in local_compose
@@ -488,7 +503,7 @@ case "$*" in
       's#.*releases/\([0-9a-f]\{40\}\)/.*#\1#p' \
       > "$FAKE_ACTIVE_RELEASE_FILE"
     ;;
-  *" exec -T db psql "*) printf '45\n' ;;
+  *" exec -T db psql "*) printf '46\n' ;;
   *"image inspect "*"org.opencontainers.image.revision"*)
     if [ -n "$FAKE_IMAGE_REVISION" ]; then
       printf '%s\n' "$FAKE_IMAGE_REVISION"
@@ -594,7 +609,7 @@ def test_deploy_promotes_only_after_smoke_passes(tmp_path):
     assert "--profile market-data up" not in log
     assert "--profile nasdaq-reference pull" not in log
     assert "--profile nasdaq-reference up" not in log
-    assert "--profile market-data stop market-sync" in log
+    assert "--profile market-data stop market-sync sector-sync" in log
     assert "--profile nasdaq-reference stop nasdaq-alias-sync" in log
     assert (
         "--profile market-data --profile nasdaq-reference "
@@ -648,11 +663,11 @@ def test_deploy_activates_only_explicit_runtime_profiles(tmp_path):
 
     assert result.returncode == 0
     assert (
-        "--profile market-data pull universe-sync market-sync"
+        "--profile market-data pull universe-sync market-sync sector-sync"
         in log
     )
     assert (
-        "--profile market-data up -d universe-sync market-sync"
+        "--profile market-data up -d universe-sync market-sync sector-sync"
         in log
     )
     assert (

--- a/agent/tests/test_release_manifest.py
+++ b/agent/tests/test_release_manifest.py
@@ -81,8 +81,8 @@ def _values():
         "dashboard_image": (
             "ghcr.io/diffen77/trading-agent/dashboard@sha256:" + "c" * 64
         ),
-        "schema_min": 47,
-        "schema_max": 47,
+        "schema_min": 48,
+        "schema_max": 48,
         "created_at": "2026-07-29T12:00:00Z",
     }
 
@@ -261,8 +261,8 @@ def test_release_manifest_round_trip_is_strict_and_shell_safe(tmp_path):
     )
 
     assert manifest.release_sha == "a" * 40
-    assert manifest.schema_min == 47
-    assert manifest.schema_max == 47
+    assert manifest.schema_min == 48
+    assert manifest.schema_max == 48
     assert manifest.agent_image.endswith("b" * 64)
     assert manifest_path.read_text().splitlines() == [
         f"RELEASE_SHA={'a' * 40}",
@@ -274,8 +274,8 @@ def test_release_manifest_round_trip_is_strict_and_shell_safe(tmp_path):
             "DASHBOARD_IMAGE=ghcr.io/diffen77/trading-agent/"
             f"dashboard@sha256:{'c' * 64}"
         ),
-        "SCHEMA_MIN=47",
-        "SCHEMA_MAX=47",
+        "SCHEMA_MIN=48",
+        "SCHEMA_MAX=48",
         "CREATED_AT=2026-07-29T12:00:00Z",
     ]
 
@@ -356,8 +356,8 @@ def test_deployment_workflows_require_immutable_release_and_approval():
     assert "docker/setup-buildx-action@v4" in build
     assert "docker/login-action@v4" in build
     assert build.count("docker/build-push-action@v7") == 2
-    assert "--schema-min 47" in build
-    assert "--schema-max 47" in build
+    assert "--schema-min 48" in build
+    assert "--schema-max 48" in build
     assert "workflow_dispatch:" in deploy
     assert "environment: production" in deploy
     assert "concurrency:" in deploy
@@ -503,7 +503,7 @@ case "$*" in
       's#.*releases/\([0-9a-f]\{40\}\)/.*#\1#p' \
       > "$FAKE_ACTIVE_RELEASE_FILE"
     ;;
-  *" exec -T db psql "*) printf '47\n' ;;
+  *" exec -T db psql "*) printf '48\n' ;;
   *"image inspect "*"org.opencontainers.image.revision"*)
     if [ -n "$FAKE_IMAGE_REVISION" ]; then
       printf '%s\n' "$FAKE_IMAGE_REVISION"

--- a/agent/tests/test_schedule.py
+++ b/agent/tests/test_schedule.py
@@ -8,6 +8,7 @@ from src.core.schedule import (
     due_routines,
     missed_routines,
     provider_routine_grace_periods,
+    provider_routine_start_delays,
     recoverable_routines,
     recovery_slots,
     stockholm_now,
@@ -123,6 +124,38 @@ def test_delayed_provider_extends_open_grace_through_delivery_window():
             first_executable_book,
             completed=set(),
             grace_periods=grace_periods,
+        )
+    }
+
+
+def test_delayed_open_waits_until_first_provider_delivery_is_possible():
+    provider = {
+        "data_type": "delayed-pre-trade-equity",
+        "nominal_delay_seconds": 900,
+        "max_transport_lag_seconds": 300,
+    }
+    start_delays = provider_routine_start_delays(provider)
+    grace_periods = provider_routine_grace_periods(provider)
+
+    too_early = datetime(2026, 8, 10, 7, 5, tzinfo=timezone.utc)
+    first_possible = datetime(2026, 8, 10, 7, 16, tzinfo=timezone.utc)
+
+    assert "open" not in {
+        routine.name
+        for routine in due_routines(
+            too_early,
+            completed=set(),
+            grace_periods=grace_periods,
+            start_delays=start_delays,
+        )
+    }
+    assert "open" in {
+        routine.name
+        for routine in due_routines(
+            first_possible,
+            completed=set(),
+            grace_periods=grace_periods,
+            start_delays=start_delays,
         )
     }
 

--- a/agent/tests/test_schema_integration.py
+++ b/agent/tests/test_schema_integration.py
@@ -117,6 +117,11 @@ REQUIRED_INSTRUMENT_COLUMNS = {
     "reference_snapshot_date",
 }
 
+REQUIRED_COMPANY_COLUMNS = {
+    "sector_source",
+    "sector_verified_at",
+}
+
 REQUIRED_REFERENCE_MEMBERSHIP_COLUMNS = {
     "cfi_code",
     "currency",
@@ -286,6 +291,15 @@ def test_runtime_schema_is_complete(connection):
             """
         )
         instrument_columns = {row[0] for row in cursor.fetchall()}
+
+        cursor.execute(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'companies'
+            """
+        )
+        company_columns = {row[0] for row in cursor.fetchall()}
 
         cursor.execute(
             """
@@ -469,7 +483,8 @@ def test_runtime_schema_is_complete(connection):
         REQUIRED_PROVIDER_VALIDATION_COLUMNS
         <= provider_validation_columns
     )
-    assert schema_version == 45
+    assert schema_version == 46
+    assert REQUIRED_COMPANY_COLUMNS <= company_columns
     assert REQUIRED_AI_DECISION_COLUMNS <= ai_decision_columns
     assert REQUIRED_MARKET_BAR_COLUMNS <= market_bar_columns
     assert REQUIRED_MARKET_QUOTE_COLUMNS <= market_quote_columns

--- a/agent/tests/test_schema_integration.py
+++ b/agent/tests/test_schema_integration.py
@@ -483,7 +483,7 @@ def test_runtime_schema_is_complete(connection):
         REQUIRED_PROVIDER_VALIDATION_COLUMNS
         <= provider_validation_columns
     )
-    assert schema_version == 46
+    assert schema_version == 47
     assert REQUIRED_COMPANY_COLUMNS <= company_columns
     assert REQUIRED_AI_DECISION_COLUMNS <= ai_decision_columns
     assert REQUIRED_MARKET_BAR_COLUMNS <= market_bar_columns

--- a/agent/tests/test_schema_integration.py
+++ b/agent/tests/test_schema_integration.py
@@ -43,6 +43,7 @@ REQUIRED_TABLES = {
     "paper_benchmark_evaluations",
     "paper_benchmark_experiments",
     "paper_benchmark_lifecycle_events",
+    "paper_execution_cost_policies",
     "portfolio_history",
     "portfolio_valuation_marks",
     "position_lots",
@@ -100,6 +101,7 @@ REQUIRED_TRADE_COLUMNS = {
     "source_book_state_id",
     "strategy_version",
     "benchmark_experiment_id",
+    "paper_execution_cost_policy_id",
 }
 
 REQUIRED_SYNC_COLUMNS = {
@@ -483,7 +485,7 @@ def test_runtime_schema_is_complete(connection):
         REQUIRED_PROVIDER_VALIDATION_COLUMNS
         <= provider_validation_columns
     )
-    assert schema_version == 47
+    assert schema_version == 48
     assert REQUIRED_COMPANY_COLUMNS <= company_columns
     assert REQUIRED_AI_DECISION_COLUMNS <= ai_decision_columns
     assert REQUIRED_MARKET_BAR_COLUMNS <= market_bar_columns

--- a/agent/tests/test_sector_schema.py
+++ b/agent/tests/test_sector_schema.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "db" / "migrations" / "046_sector_classification.sql"
+
+
+def test_sector_migration_records_source_and_verification_time():
+    sql = MIGRATION.read_text(encoding="utf-8")
+
+    assert "sector_source" in sql
+    assert "sector_verified_at" in sql
+    assert "companies_sector_provenance_pair" in sql

--- a/agent/tests/test_sector_sync.py
+++ b/agent/tests/test_sector_sync.py
@@ -1,0 +1,41 @@
+import pytest
+
+from src.data.market_data import MarketDataError
+from src.sector_sync import build_sector_sync_service, run_daemon
+
+
+class _Database:
+    pass
+
+
+class _Service:
+    def __init__(self):
+        self.calls = 0
+
+    def sync(self):
+        self.calls += 1
+        raise KeyboardInterrupt
+
+
+def test_sector_sync_is_disabled_by_default():
+    with pytest.raises(MarketDataError, match="disabled"):
+        build_sector_sync_service(database=_Database(), environ={})
+
+
+def test_sector_sync_requires_bounded_coverage_threshold():
+    with pytest.raises(MarketDataError, match="coverage"):
+        build_sector_sync_service(
+            database=_Database(),
+            environ={
+                "ENABLE_NASDAQ_SECTOR_SYNC": "true",
+                "NASDAQ_SECTOR_MINIMUM_COVERAGE": "0.20",
+            },
+        )
+
+
+def test_sector_daemon_runs_immediately_and_stops_cleanly():
+    service = _Service()
+
+    run_daemon(service=service, interval_seconds=86400)
+
+    assert service.calls == 1

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -787,7 +787,9 @@ function PositionCard({ pos }: { pos: Position }) {
   const entry = parseFloat(String(pos.avg_price)) || 0
   const displayName = pos.company_name?.trim() || pos.ticker
   const identifierKind = /^[A-Z]{2}[A-Z0-9]{10}$/.test(pos.ticker) ? 'ISIN' : 'Ticker'
-  const sectorLabel = pos.sector === 'Unclassified' ? 'Ej klassificerad' : pos.sector
+  const sectorLabel = pos.sector && pos.sector !== 'Unclassified'
+    ? pos.sector
+    : ''
 
   // Progress between stop_loss and target
   const range = target - sl

--- a/dashboard/lib/server/operational-status.mjs
+++ b/dashboard/lib/server/operational-status.mjs
@@ -1,7 +1,7 @@
 import { buildActivationActions } from './activation-actions.mjs'
 
 
-export const REQUIRED_SCHEMA_VERSION = 45
+export const REQUIRED_SCHEMA_VERSION = 46
 
 
 const OPERATIONAL_STATUS_QUERY = `

--- a/dashboard/lib/server/operational-status.mjs
+++ b/dashboard/lib/server/operational-status.mjs
@@ -1,7 +1,7 @@
 import { buildActivationActions } from './activation-actions.mjs'
 
 
-export const REQUIRED_SCHEMA_VERSION = 46
+export const REQUIRED_SCHEMA_VERSION = 47
 
 
 const OPERATIONAL_STATUS_QUERY = `

--- a/dashboard/lib/server/operational-status.mjs
+++ b/dashboard/lib/server/operational-status.mjs
@@ -1,7 +1,7 @@
 import { buildActivationActions } from './activation-actions.mjs'
 
 
-export const REQUIRED_SCHEMA_VERSION = 47
+export const REQUIRED_SCHEMA_VERSION = 48
 
 
 const OPERATIONAL_STATUS_QUERY = `

--- a/dashboard/tests/continuous-learning.test.mjs
+++ b/dashboard/tests/continuous-learning.test.mjs
@@ -79,7 +79,7 @@ test('learning API uses append-only prediction and outcome journals', () => {
 
 
 test(
-  'continuous learning query executes against schema 46',
+  'continuous learning query executes against schema 47',
   { skip: !process.env.TEST_DATABASE_URL },
   async () => {
     const marker = 'getDatabasePool().query(`'

--- a/dashboard/tests/continuous-learning.test.mjs
+++ b/dashboard/tests/continuous-learning.test.mjs
@@ -79,7 +79,7 @@ test('learning API uses append-only prediction and outcome journals', () => {
 
 
 test(
-  'continuous learning query executes against schema 45',
+  'continuous learning query executes against schema 46',
   { skip: !process.env.TEST_DATABASE_URL },
   async () => {
     const marker = 'getDatabasePool().query(`'

--- a/dashboard/tests/continuous-learning.test.mjs
+++ b/dashboard/tests/continuous-learning.test.mjs
@@ -79,7 +79,7 @@ test('learning API uses append-only prediction and outcome journals', () => {
 
 
 test(
-  'continuous learning query executes against schema 47',
+  'continuous learning query executes against schema 48',
   { skip: !process.env.TEST_DATABASE_URL },
   async () => {
     const marker = 'getDatabasePool().query(`'

--- a/dashboard/tests/docker-runtime.test.mjs
+++ b/dashboard/tests/docker-runtime.test.mjs
@@ -36,7 +36,7 @@ test('standalone runtime binds to the container interface used by healthcheck', 
 test('healthcheck and operations share one required schema version', () => {
   assert.match(
     operationalStatus,
-    /export const REQUIRED_SCHEMA_VERSION = 45/,
+    /export const REQUIRED_SCHEMA_VERSION = 46/,
   )
   assert.match(healthRoute, /REQUIRED_SCHEMA_VERSION/)
   assert.doesNotMatch(healthRoute, /version !== \d+/)
@@ -65,4 +65,9 @@ test('analysis API resolves decision identifiers to company names', () => {
   assert.match(decisionsRoute, /reasoning_effort/)
   assert.match(dashboardPage, /Aktiv analysmodell/)
   assert.match(dashboardPage, /GPT-5\.6 Sol/)
+})
+
+test('position cards omit an unverified sector badge', () => {
+  assert.doesNotMatch(dashboardPage, /Ej klassificerad/)
+  assert.match(dashboardPage, /pos\.sector !== 'Unclassified'/)
 })

--- a/dashboard/tests/docker-runtime.test.mjs
+++ b/dashboard/tests/docker-runtime.test.mjs
@@ -36,7 +36,7 @@ test('standalone runtime binds to the container interface used by healthcheck', 
 test('healthcheck and operations share one required schema version', () => {
   assert.match(
     operationalStatus,
-    /export const REQUIRED_SCHEMA_VERSION = 46/,
+    /export const REQUIRED_SCHEMA_VERSION = 47/,
   )
   assert.match(healthRoute, /REQUIRED_SCHEMA_VERSION/)
   assert.doesNotMatch(healthRoute, /version !== \d+/)

--- a/dashboard/tests/docker-runtime.test.mjs
+++ b/dashboard/tests/docker-runtime.test.mjs
@@ -36,7 +36,7 @@ test('standalone runtime binds to the container interface used by healthcheck', 
 test('healthcheck and operations share one required schema version', () => {
   assert.match(
     operationalStatus,
-    /export const REQUIRED_SCHEMA_VERSION = 47/,
+    /export const REQUIRED_SCHEMA_VERSION = 48/,
   )
   assert.match(healthRoute, /REQUIRED_SCHEMA_VERSION/)
   assert.doesNotMatch(healthRoute, /version !== \d+/)

--- a/dashboard/tests/operational-status.integration.test.mjs
+++ b/dashboard/tests/operational-status.integration.test.mjs
@@ -18,7 +18,7 @@ const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 
 
 test(
-  'operational status query fails closed against schema 46',
+  'operational status query fails closed against schema 47',
   { skip: !TEST_DATABASE_URL },
   async () => {
     const pool = new pg.Pool({
@@ -47,7 +47,7 @@ test(
 
 
 test(
-  'authorized dashboard quote view executes against schema 46',
+  'authorized dashboard quote view executes against schema 47',
   { skip: !TEST_DATABASE_URL },
   async () => {
     const pool = new pg.Pool({

--- a/dashboard/tests/operational-status.integration.test.mjs
+++ b/dashboard/tests/operational-status.integration.test.mjs
@@ -18,7 +18,7 @@ const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 
 
 test(
-  'operational status query fails closed against schema 47',
+  'operational status query fails closed against schema 48',
   { skip: !TEST_DATABASE_URL },
   async () => {
     const pool = new pg.Pool({
@@ -28,7 +28,7 @@ test(
     try {
       const status = await loadOperationalStatus(pool)
 
-      assert.equal(status.schema_version, 46)
+      assert.equal(status.schema_version, 48)
       assert.equal(status.overall_status, 'BLOCKED')
       assert.ok(status.blockers.includes('REFERENCE_SNAPSHOT_MISSING'))
       assert.ok(status.blockers.includes('QUOTE_PROVIDER_NOT_READY'))
@@ -47,7 +47,7 @@ test(
 
 
 test(
-  'authorized dashboard quote view executes against schema 47',
+  'authorized dashboard quote view executes against schema 48',
   { skip: !TEST_DATABASE_URL },
   async () => {
     const pool = new pg.Pool({

--- a/dashboard/tests/operational-status.integration.test.mjs
+++ b/dashboard/tests/operational-status.integration.test.mjs
@@ -18,7 +18,7 @@ const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 
 
 test(
-  'operational status query fails closed against schema 45',
+  'operational status query fails closed against schema 46',
   { skip: !TEST_DATABASE_URL },
   async () => {
     const pool = new pg.Pool({
@@ -28,7 +28,7 @@ test(
     try {
       const status = await loadOperationalStatus(pool)
 
-      assert.equal(status.schema_version, 45)
+      assert.equal(status.schema_version, 46)
       assert.equal(status.overall_status, 'BLOCKED')
       assert.ok(status.blockers.includes('REFERENCE_SNAPSHOT_MISSING'))
       assert.ok(status.blockers.includes('QUOTE_PROVIDER_NOT_READY'))
@@ -47,7 +47,7 @@ test(
 
 
 test(
-  'authorized dashboard quote view executes against schema 45',
+  'authorized dashboard quote view executes against schema 46',
   { skip: !TEST_DATABASE_URL },
   async () => {
     const pool = new pg.Pool({

--- a/dashboard/tests/operational-status.test.mjs
+++ b/dashboard/tests/operational-status.test.mjs
@@ -10,7 +10,7 @@ import {
 function readySnapshot() {
   return {
     checked_at: '2026-07-29T10:00:00.000Z',
-    schema_version: 45,
+    schema_version: 46,
     strategy: {
       version: 'momentum-report-swing-v1',
       config_hash: 'a'.repeat(64),

--- a/dashboard/tests/operational-status.test.mjs
+++ b/dashboard/tests/operational-status.test.mjs
@@ -10,7 +10,7 @@ import {
 function readySnapshot() {
   return {
     checked_at: '2026-07-29T10:00:00.000Z',
-    schema_version: 46,
+    schema_version: 48,
     strategy: {
       version: 'momentum-report-swing-v1',
       config_hash: 'a'.repeat(64),

--- a/db/migrations/046_sector_classification.sql
+++ b/db/migrations/046_sector_classification.sql
@@ -1,0 +1,14 @@
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS sector_source VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS sector_verified_at TIMESTAMPTZ;
+
+ALTER TABLE companies
+    DROP CONSTRAINT IF EXISTS companies_sector_provenance_pair;
+
+ALTER TABLE companies
+    ADD CONSTRAINT companies_sector_provenance_pair CHECK (
+        (sector_source IS NULL) = (sector_verified_at IS NULL)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_companies_sector_source
+    ON companies (sector_source, sector_verified_at);

--- a/db/migrations/047_bounded_candidate_outcomes.sql
+++ b/db/migrations/047_bounded_candidate_outcomes.sql
@@ -1,0 +1,176 @@
+-- Preserve point-in-time evidence while tolerating a bounded unavailable book
+-- minute. The journal stores the actual event minute selected from the source.
+
+CREATE OR REPLACE FUNCTION validate_candidate_entry_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    prediction candidate_predictions%ROWTYPE;
+    prediction_state pre_trade_book_states%ROWTYPE;
+    prediction_batch pre_trade_batches%ROWTYPE;
+    entry_state pre_trade_book_states%ROWTYPE;
+    entry_batch pre_trade_batches%ROWTYPE;
+    expected_price NUMERIC(24, 8);
+    requested_event_time TIMESTAMPTZ;
+BEGIN
+    SELECT * INTO prediction
+    FROM candidate_predictions
+    WHERE id = NEW.prediction_id
+    FOR SHARE;
+
+    SELECT * INTO prediction_state
+    FROM pre_trade_book_states
+    WHERE id = prediction.source_book_state_id
+    FOR SHARE;
+
+    SELECT * INTO prediction_batch
+    FROM pre_trade_batches
+    WHERE id = prediction_state.batch_id
+    FOR SHARE;
+
+    SELECT * INTO entry_state
+    FROM pre_trade_book_states
+    WHERE id = NEW.source_book_state_id
+    FOR SHARE;
+
+    SELECT * INTO entry_batch
+    FROM pre_trade_batches
+    WHERE id = entry_state.batch_id
+    FOR SHARE;
+
+    requested_event_time := DATE_TRUNC('minute', prediction.observed_at);
+    expected_price := (entry_state.bid_price + entry_state.ask_price) / 2;
+
+    IF (
+        prediction.id IS NULL
+        OR prediction_state.id IS NULL
+        OR prediction_batch.id IS NULL
+        OR entry_state.id IS NULL
+        OR entry_batch.id IS NULL
+        OR entry_state.instrument_id != prediction_state.instrument_id
+        OR entry_batch.provider_contract_id
+            != prediction_batch.provider_contract_id
+        OR NEW.entry_event_time < requested_event_time
+        OR NEW.entry_event_time
+            > requested_event_time + INTERVAL '2 minutes'
+        OR entry_batch.report_minute != NEW.entry_event_time
+        OR entry_state.bid_price IS NULL
+        OR entry_state.ask_price IS NULL
+        OR entry_state.bid_quantity <= 0
+        OR entry_state.ask_quantity <= 0
+        OR entry_state.trading_system != 'CLOB'
+        OR entry_state.trading_phase != 'COTR'
+        OR NOT EXISTS (
+            SELECT 1
+            FROM pre_trade_stream_cursors seal
+            WHERE seal.batch_id = entry_batch.id
+        )
+        OR entry_state.received_at > NEW.evaluated_at
+        OR NEW.entry_price != expected_price
+    ) THEN
+        RAISE EXCEPTION
+            'candidate entry evidence does not match prediction time';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION validate_candidate_outcome_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    prediction candidate_predictions%ROWTYPE;
+    entry candidate_prediction_entries%ROWTYPE;
+    source_state pre_trade_book_states%ROWTYPE;
+    source_batch pre_trade_batches%ROWTYPE;
+    prediction_state pre_trade_book_states%ROWTYPE;
+    prediction_batch pre_trade_batches%ROWTYPE;
+    expected_price NUMERIC(24, 8);
+    expected_return_bps NUMERIC(18, 8);
+    requested_target_time TIMESTAMPTZ;
+BEGIN
+    SELECT * INTO prediction
+    FROM candidate_predictions
+    WHERE id = NEW.prediction_id
+    FOR SHARE;
+
+    SELECT * INTO entry
+    FROM candidate_prediction_entries
+    WHERE id = NEW.entry_id
+    FOR SHARE;
+
+    SELECT * INTO source_state
+    FROM pre_trade_book_states
+    WHERE id = NEW.source_book_state_id
+    FOR SHARE;
+
+    SELECT * INTO source_batch
+    FROM pre_trade_batches
+    WHERE id = source_state.batch_id
+    FOR SHARE;
+
+    SELECT * INTO prediction_state
+    FROM pre_trade_book_states
+    WHERE id = prediction.source_book_state_id
+    FOR SHARE;
+
+    SELECT * INTO prediction_batch
+    FROM pre_trade_batches
+    WHERE id = prediction_state.batch_id
+    FOR SHARE;
+
+    requested_target_time := entry.entry_event_time
+        + NEW.horizon_minutes * INTERVAL '1 minute';
+    expected_price := (source_state.bid_price + source_state.ask_price) / 2;
+    expected_return_bps :=
+        ((expected_price / entry.entry_price) - 1) * 10000;
+
+    IF (
+        prediction.id IS NULL
+        OR entry.id IS NULL
+        OR entry.prediction_id != prediction.id
+        OR NOT NEW.horizon_minutes
+            = ANY(prediction.expected_horizons_minutes)
+        OR source_state.id IS NULL
+        OR source_batch.id IS NULL
+        OR prediction_state.id IS NULL
+        OR prediction_batch.id IS NULL
+        OR source_state.instrument_id != prediction_state.instrument_id
+        OR source_batch.provider_contract_id
+            != prediction_batch.provider_contract_id
+        OR source_state.bid_price IS NULL
+        OR source_state.ask_price IS NULL
+        OR source_state.bid_quantity <= 0
+        OR source_state.ask_quantity <= 0
+        OR source_state.trading_system != 'CLOB'
+        OR source_state.trading_phase != 'COTR'
+        OR NOT EXISTS (
+            SELECT 1
+            FROM pre_trade_stream_cursors seal
+            WHERE seal.batch_id = source_batch.id
+        )
+        OR NEW.target_event_time < requested_target_time
+        OR NEW.target_event_time
+            > requested_target_time + INTERVAL '2 minutes'
+        OR source_batch.report_minute != NEW.target_event_time
+        OR source_state.received_at > NEW.evaluated_at
+        OR NEW.observed_price != expected_price
+        OR ABS(NEW.return_bps - expected_return_bps) > 0.00000001
+        OR NOT EXISTS (
+            SELECT 1
+            FROM market_sessions market_session
+            WHERE market_session.mic = 'XSTO'
+              AND market_session.status IN ('OPEN', 'HALF_DAY')
+              AND entry.entry_event_time >= market_session.opens_at
+              AND entry.entry_event_time < market_session.closes_at
+              AND NEW.target_event_time < market_session.closes_at
+        )
+    ) THEN
+        RAISE EXCEPTION
+            'candidate outcome evidence does not match prediction';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/db/migrations/048_default_paper_execution_costs.sql
+++ b/db/migrations/048_default_paper_execution_costs.sql
@@ -1,0 +1,304 @@
+CREATE TABLE paper_execution_cost_policies (
+    id BIGSERIAL PRIMARY KEY,
+    model_key VARCHAR(80) NOT NULL UNIQUE,
+    execution_price_source VARCHAR(40) NOT NULL,
+    fee_bps DECIMAL(10, 4) NOT NULL,
+    spread_bps DECIMAL(10, 4) NOT NULL,
+    slippage_bps DECIMAL(10, 4) NOT NULL,
+    minimum_fee DECIMAL(20, 8) NOT NULL,
+    fee_source_url TEXT NOT NULL,
+    fee_verified_at TIMESTAMPTZ NOT NULL,
+    slippage_assumption TEXT NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (execution_price_source IN (
+        'TOP_OF_BOOK_PLUS_SLIPPAGE',
+        'LAST_TRADE_PLUS_BPS'
+    )),
+    CHECK (fee_bps BETWEEN 0 AND 1000),
+    CHECK (spread_bps BETWEEN 0 AND 1000),
+    CHECK (slippage_bps BETWEEN 0 AND 1000),
+    CHECK (minimum_fee BETWEEN 0 AND 10000),
+    CHECK (
+        execution_price_source != 'TOP_OF_BOOK_PLUS_SLIPPAGE'
+        OR spread_bps = 0
+    )
+);
+
+CREATE UNIQUE INDEX uq_active_paper_execution_cost_policy
+ON paper_execution_cost_policies (active)
+WHERE active = TRUE;
+
+INSERT INTO paper_execution_cost_policies (
+    model_key,
+    execution_price_source,
+    fee_bps,
+    spread_bps,
+    slippage_bps,
+    minimum_fee,
+    fee_source_url,
+    fee_verified_at,
+    slippage_assumption,
+    active
+)
+VALUES (
+    'se-retail-public-top-book-v1',
+    'TOP_OF_BOOK_PLUS_SLIPPAGE',
+    25,
+    0,
+    5,
+    1,
+    'https://www.nordnet.se/kundservice/prislista',
+    '2026-08-11T00:00:00Z',
+    'Conservative deterministic paper assumption; actual spread is taken from the sealed executable book.',
+    TRUE
+);
+
+ALTER TABLE trades
+ADD COLUMN paper_execution_cost_policy_id BIGINT
+    REFERENCES paper_execution_cost_policies(id) ON DELETE RESTRICT;
+
+ALTER TABLE trades
+ADD CONSTRAINT ck_trade_execution_cost_contract
+CHECK (
+    benchmark_experiment_id IS NULL
+    OR paper_execution_cost_policy_id IS NULL
+);
+
+CREATE INDEX idx_trades_paper_execution_cost_policy
+ON trades (paper_execution_cost_policy_id, executed_at DESC);
+
+CREATE OR REPLACE FUNCTION apply_default_paper_execution_costs()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    blocking_experiment_status VARCHAR(20);
+    policy_id BIGINT;
+    policy_source VARCHAR(40);
+    policy_fee_bps DECIMAL(10, 4);
+    policy_spread_bps DECIMAL(10, 4);
+    policy_slippage_bps DECIMAL(10, 4);
+    policy_minimum_fee DECIMAL(20, 8);
+    source_bid DECIMAL(20, 8);
+    source_ask DECIMAL(20, 8);
+    source_price DECIMAL(20, 8);
+    source_ticker VARCHAR(20);
+    expected_quote_price DECIMAL(20, 8);
+    expected_execution_price DECIMAL(20, 8);
+    expected_total_value DECIMAL(20, 8);
+    expected_fee_amount DECIMAL(20, 8);
+    expected_spread_cost DECIMAL(20, 8);
+    expected_slippage_cost DECIMAL(20, 8);
+    expected_net_cash_effect DECIMAL(20, 8);
+    direction DECIMAL(2, 0);
+BEGIN
+    SELECT status
+    INTO blocking_experiment_status
+    FROM paper_benchmark_experiments
+    WHERE status IN ('RUNNING', 'APPROVED', 'PAUSED')
+    ORDER BY id
+    LIMIT 1;
+
+    IF blocking_experiment_status IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.benchmark_experiment_id IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.source_book_state_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT
+        id,
+        execution_price_source,
+        fee_bps,
+        spread_bps,
+        slippage_bps,
+        minimum_fee
+    INTO
+        policy_id,
+        policy_source,
+        policy_fee_bps,
+        policy_spread_bps,
+        policy_slippage_bps,
+        policy_minimum_fee
+    FROM paper_execution_cost_policies
+    WHERE active = TRUE;
+
+    IF policy_id IS NULL THEN
+        RAISE EXCEPTION 'active paper execution cost policy is missing';
+    END IF;
+    IF (
+        NEW.paper_execution_cost_policy_id IS NOT NULL
+        AND NEW.paper_execution_cost_policy_id != policy_id
+    ) THEN
+        RAISE EXCEPTION 'trade references the wrong paper execution cost policy';
+    END IF;
+
+    direction = CASE WHEN NEW.action = 'BUY' THEN 1 ELSE -1 END;
+    IF NEW.source_book_state_id IS NOT NULL THEN
+        IF policy_source != 'TOP_OF_BOOK_PLUS_SLIPPAGE' THEN
+            RAISE EXCEPTION 'paper cost policy requires last-trade evidence';
+        END IF;
+        SELECT
+            state.bid_price,
+            state.ask_price,
+            company.ticker
+        INTO source_bid, source_ask, source_ticker
+        FROM pre_trade_book_states state
+        JOIN instruments instrument ON instrument.id = state.instrument_id
+        JOIN companies company ON company.instrument_id = instrument.id
+        WHERE state.id = NEW.source_book_state_id;
+
+        IF (
+            source_bid IS NULL
+            OR source_ask IS NULL
+            OR source_bid > source_ask
+            OR source_ticker != NEW.ticker
+        ) THEN
+            RAISE EXCEPTION 'paper cost policy requires matching two-sided book evidence';
+        END IF;
+        expected_quote_price = ROUND((source_bid + source_ask) / 2, 8);
+        source_price = CASE
+            WHEN NEW.action = 'BUY' THEN source_ask
+            ELSE source_bid
+        END;
+        expected_execution_price = ROUND(
+            source_price * (
+                1 + direction * policy_slippage_bps / 10000
+            ),
+            8
+        );
+        expected_spread_cost = ROUND(
+            ABS(source_price - expected_quote_price) * NEW.shares,
+            2
+        );
+    ELSE
+        IF NEW.source_quote_id IS NOT NULL THEN
+            SELECT quote.last_price, company.ticker
+            INTO source_price, source_ticker
+            FROM market_quotes quote
+            JOIN instruments instrument ON instrument.id = quote.instrument_id
+            JOIN companies company ON company.instrument_id = instrument.id
+            WHERE quote.id = NEW.source_quote_id;
+            IF source_price IS NULL OR source_ticker != NEW.ticker THEN
+                RAISE EXCEPTION 'paper cost policy requires matching quote evidence';
+            END IF;
+        ELSE
+            source_price = NEW.price;
+        END IF;
+        expected_quote_price = ROUND(source_price, 8);
+        expected_execution_price = ROUND(
+            source_price * (
+                1 + direction * (
+                    policy_spread_bps / 2 + policy_slippage_bps
+                ) / 10000
+            ),
+            8
+        );
+        expected_spread_cost = ROUND(
+            source_price * NEW.shares * policy_spread_bps / 20000,
+            2
+        );
+    END IF;
+
+    expected_total_value = ROUND(expected_execution_price * NEW.shares, 2);
+    expected_fee_amount = GREATEST(
+        ROUND(expected_total_value * policy_fee_bps / 10000, 2),
+        ROUND(policy_minimum_fee, 2)
+    );
+    expected_slippage_cost = ROUND(
+        source_price * NEW.shares * policy_slippage_bps / 10000,
+        2
+    );
+    expected_net_cash_effect = CASE
+        WHEN NEW.action = 'BUY'
+            THEN expected_total_value + expected_fee_amount
+        ELSE expected_total_value - expected_fee_amount
+    END;
+
+    IF NEW.paper_execution_cost_policy_id IS NOT NULL AND (
+        NEW.quote_price != expected_quote_price
+        OR NEW.price != expected_execution_price
+        OR NEW.total_value != expected_total_value
+        OR NEW.fee_amount != expected_fee_amount
+        OR NEW.spread_cost != expected_spread_cost
+        OR NEW.slippage_cost != expected_slippage_cost
+        OR NEW.net_cash_effect != expected_net_cash_effect
+    ) THEN
+        RAISE EXCEPTION 'trade execution costs do not match the active paper policy';
+    END IF;
+
+    NEW.paper_execution_cost_policy_id = policy_id;
+    NEW.quote_price = expected_quote_price;
+    NEW.price = expected_execution_price;
+    NEW.total_value = expected_total_value;
+    NEW.fee_amount = expected_fee_amount;
+    NEW.spread_cost = expected_spread_cost;
+    NEW.slippage_cost = expected_slippage_cost;
+    NEW.net_cash_effect = expected_net_cash_effect;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_tag_00_apply_default_paper_execution_costs
+BEFORE INSERT ON trades
+FOR EACH ROW
+EXECUTE FUNCTION apply_default_paper_execution_costs();
+
+DROP TRIGGER trg_tag_paper_benchmark_trade ON trades;
+CREATE TRIGGER trg_tag_paper_benchmark_trade
+BEFORE INSERT ON trades
+FOR EACH ROW
+WHEN (NEW.paper_execution_cost_policy_id IS NULL)
+EXECUTE FUNCTION tag_paper_benchmark_trade();
+
+CREATE OR REPLACE FUNCTION protect_paper_execution_cost_evidence()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF OLD.paper_execution_cost_policy_id IS NOT NULL THEN
+            RAISE EXCEPTION 'paper execution cost evidence is append-only';
+        END IF;
+        RETURN OLD;
+    END IF;
+    IF (
+        OLD.paper_execution_cost_policy_id IS NOT NULL
+        OR NEW.paper_execution_cost_policy_id IS NOT NULL
+    ) AND ROW(
+        OLD.paper_execution_cost_policy_id,
+        OLD.quote_price,
+        OLD.price,
+        OLD.total_value,
+        OLD.fee_amount,
+        OLD.spread_cost,
+        OLD.slippage_cost,
+        OLD.net_cash_effect,
+        OLD.source_quote_id,
+        OLD.source_book_state_id
+    ) IS DISTINCT FROM ROW(
+        NEW.paper_execution_cost_policy_id,
+        NEW.quote_price,
+        NEW.price,
+        NEW.total_value,
+        NEW.fee_amount,
+        NEW.spread_cost,
+        NEW.slippage_cost,
+        NEW.net_cash_effect,
+        NEW.source_quote_id,
+        NEW.source_book_state_id
+    ) THEN
+        RAISE EXCEPTION 'paper execution cost evidence is append-only';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_protect_paper_execution_cost_evidence
+BEFORE UPDATE OR DELETE ON trades
+FOR EACH ROW
+EXECUTE FUNCTION protect_paper_execution_cost_evidence();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -282,6 +282,25 @@ services:
         read_only: true
     restart: on-failure:5
 
+  sector-sync:
+    profiles: ["market-data"]
+    build:
+      context: ./agent
+      dockerfile: Dockerfile
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      universe-sync:
+        condition: service_healthy
+    command: ["python", "-m", "src.sector_sync", "daemon"]
+    environment:
+      DATABASE_URL: postgresql://trading:${DB_PASSWORD:?DB_PASSWORD must be set}@db:5432/trading_agent
+      ENABLE_NASDAQ_SECTOR_SYNC: ${ENABLE_NASDAQ_SECTOR_SYNC:-true}
+      NASDAQ_SECTOR_MINIMUM_COVERAGE: ${NASDAQ_SECTOR_MINIMUM_COVERAGE:-0.95}
+      SECTOR_SYNC_INTERVAL_SECONDS: ${SECTOR_SYNC_INTERVAL_SECONDS:-86400}
+      PYTHONUNBUFFERED: 1
+    restart: unless-stopped
+
   dashboard:
     build:
       context: ./dashboard

--- a/docs/decisions/ADR-004-default-paper-execution-costs.md
+++ b/docs/decisions/ADR-004-default-paper-execution-costs.md
@@ -1,0 +1,77 @@
+# ADR-004: Realistiska kostnader för vanlig papertrading
+
+## Status
+
+Accepterad
+
+## Datum
+
+2026-08-11
+
+## Kontext
+
+Vanlig papertrading utanför ett aktivt forward-experiment bokförde
+tidigare fills utan avgift, spread eller slippage. Det gjorde
+portföljutfallet för optimistiskt och försvårade beviset att agenten
+kan skapa nettoavkastning över tid. Projektet ska samtidigt kunna
+köras med noll kronor i extern datakostnad och det strikta
+OMXSGI-experimentet saknar ännu ett separat auktoriserat indexflöde.
+
+Det publika pre-trade-flödet innehåller förseglad bid/ask-evidens. Den
+kan därför bära en reproducerbar paperfill utan att skapa syntetisk
+spread eller aktivera ett benchmark med ofullständiga datarättigheter.
+
+## Beslut
+
+1. En vanlig paperfill med förseglad orderbok belastas med faktisk
+   halvspread från midpoint till exekverbar sida.
+2. Exekveringspriset belastas dessutom med en deterministisk
+   slippage på 5 baspunkter. Detta är ett konservativt internt
+   antagande, inte leverantörsdata.
+3. Courtage följer den publika svenska Mini-nivån: 0,25 procent med
+   minst 1 SEK per affär.
+4. Modellen lagras som en aktiv, versionsidentifierad policy i
+   PostgreSQL. Varje berörd trade binds till exakt policy-ID och
+   databasen räknar eller verifierar pris, avgift, spread, slippage
+   och nettokassaflöde.
+5. Policyn används bara när traden har en verifierad
+   `source_book_state_id`. Legacy- och testvägar utan orderbok ändras
+   inte och kan inte utge sig för att ha observerad spread.
+6. Ett aktivt, förregistrerat benchmark fortsätter använda sin egen
+   frysta kostnadsmodell. Standardpolicyn får aldrig skriva över eller
+   kringgå benchmarkkontraktet.
+7. Befintliga historiska trades skrivs inte om. Modellen gäller
+   framåtriktat från schema 48.
+
+## Alternativ som övervägdes
+
+### Fortsatta nollkostnadsfills
+
+Enkelt men systematiskt optimistiskt. Avvisat eftersom målet är
+nettoavkastning efter kostnader.
+
+### Starta det strikta OMXSGI-experimentet
+
+Avvisat tills separat auktoriserad OMXSGI-data och nödvändig
+provider-evidens finns. Ett benchmark får inte fabriceras för att
+låsa upp paperkostnader.
+
+### Fast syntetisk spread i baspunkter
+
+Avvisat för orderboksfills eftersom bid/ask redan innehåller den
+faktiska spreaden. Ett extra spreadpåslag skulle dubbelräkna kostnaden.
+
+## Konsekvenser
+
+Nya papertrades får lägre men mer trovärdig nettoavkastning. Små
+affärer träffas av minimicourtaget och illikvida instrument av sin
+faktiska spread. Resultatet blir jämförbart över tid eftersom samma
+policy finns både i beräkningen och som append-only trade-evidens.
+
+Slippageantagandet behöver omprövas när verkliga mäklarfills finns.
+En sådan ändring ska skapa en ny policyversion; gamla trades ska
+fortsätta peka på den modell som gällde när de skapades.
+
+## Officiell kostnadskälla
+
+- <https://www.nordnet.se/kundservice/prislista>

--- a/ops/release/compose.production.yml
+++ b/ops/release/compose.production.yml
@@ -353,6 +353,29 @@ services:
       start_period: 15s
     restart: unless-stopped
 
+  sector-sync:
+    profiles: ["market-data"]
+    image: ${AGENT_IMAGE:?AGENT_IMAGE must be an immutable digest}
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      universe-sync:
+        condition: service_healthy
+    command: ["python", "-m", "src.sector_sync", "daemon"]
+    environment:
+      DATABASE_URL_FILE: /run/secrets/database_url
+      ENABLE_NASDAQ_SECTOR_SYNC: ${ENABLE_NASDAQ_SECTOR_SYNC:-true}
+      NASDAQ_SECTOR_MINIMUM_COVERAGE: ${NASDAQ_SECTOR_MINIMUM_COVERAGE:-0.95}
+      SECTOR_SYNC_INTERVAL_SECONDS: ${SECTOR_SYNC_INTERVAL_SECONDS:-86400}
+      PYTHONUNBUFFERED: "1"
+    secrets:
+      - source: database_url
+        target: database_url
+        uid: "10001"
+        gid: "10001"
+        mode: 0400
+    restart: unless-stopped
+
   market-sync:
     profiles: ["market-data"]
     image: ${AGENT_IMAGE:?AGENT_IMAGE must be an immutable digest}

--- a/ops/release/deploy.sh
+++ b/ops/release/deploy.sh
@@ -251,7 +251,7 @@ activate_release() {
     verify_image_provenance "$release" || return 1
     if profile_enabled market-data; then
         compose_release "$release" --profile market-data \
-            pull universe-sync market-sync || return 1
+            pull universe-sync market-sync sector-sync || return 1
     fi
     if profile_enabled nasdaq-reference; then
         compose_release "$release" --profile nasdaq-reference \
@@ -286,10 +286,10 @@ activate_release() {
     fi
     if profile_enabled market-data; then
         compose_release "$release" --profile market-data \
-            up -d universe-sync market-sync || return 1
+            up -d universe-sync market-sync sector-sync || return 1
     else
         compose_release "$release" --profile market-data \
-            stop market-sync || return 1
+            stop market-sync sector-sync || return 1
     fi
     if profile_enabled nasdaq-reference; then
         compose_release "$release" --profile nasdaq-reference \

--- a/ops/release/release_manifest.py
+++ b/ops/release/release_manifest.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 
 
-REQUIRED_SCHEMA = 47
+REQUIRED_SCHEMA = 48
 _SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 _DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _PREFIX_PATTERN = re.compile(

--- a/ops/release/release_manifest.py
+++ b/ops/release/release_manifest.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 
 
-REQUIRED_SCHEMA = 46
+REQUIRED_SCHEMA = 47
 _SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 _DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _PREFIX_PATTERN = re.compile(

--- a/ops/release/release_manifest.py
+++ b/ops/release/release_manifest.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 
 
-REQUIRED_SCHEMA = 45
+REQUIRED_SCHEMA = 46
 _SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 _DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _PREFIX_PATTERN = re.compile(


### PR DESCRIPTION
Adds verified XSTO sector enrichment, bounded exact-source outcome labeling, realistic audited paper execution costs, provider-aware open scheduling, and smaller deep AI context. Schema advances to 48. Local verification: 692 agent tests, 67 dashboard tests with PostgreSQL integration, production dashboard build, Python audit, and npm audit all passed. Strict OMXSGI benchmark remains separate and is not activated without authorized index evidence.