### PR TITLE
docs: record verified schema 48 staging state

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -10,34 +10,33 @@ historiska journalen och ska inte användas som ensam källa för dagens drift.
 - Systemet är en fail-closed papertradingplattform. Riktiga pengar och
   brokerkoppling är blockerade.
 - Kanonisk kod finns på `main` i `diffen77/trading-agent` efter merge av
-  [PR #10](https://github.com/diffen77/trading-agent/pull/10) och den
-  efterföljande Actions-uppgraderingen i
-  [PR #11](https://github.com/diffen77/trading-agent/pull/11).
+  [PR #20](https://github.com/diffen77/trading-agent/pull/20) och
+  [PR #21](https://github.com/diffen77/trading-agent/pull/21).
 - Deployad staging-release är
-  `a1ca715380f3e496cddcfc7373205b84adbac4dd`.
+  `8805c15250fd70be08080b6a140adc359d655ad6`.
 - PostgreSQL är system of record. Neo4j och Cortex är härledda projekt- och
   tradingminnen, inte ersättning för Git eller ledgern.
 
 ## Verifierad kod och release
 
-Följande ändringar ingår nu i `main`:
+Följande dag-ett-förbättringar ingår nu i `main`:
 
-- `dd8edb7`: öppningsrutinens grace beräknas från leverantörens nominella
-  fördröjning och tillåtna lagg; fallet 09:20:45 är regressionstestat;
-- `079400b`: images får OCI-labels för källa och Git-revision, och deploy
-  verifierar dem före migrering;
-- `f55ec2e`: fail-closed benchmark-preflight och schema 45, som binder
-  leverantörsvalidering till exakt referenssnapshot och checksumma;
-- `9f0439c`: checksummebunden leveranskontroll för licensierad historik,
-  corporate actions, OMXSGI, kalender och användningsrätt.
+- `dd77180`: Nasdaq-baserad XSTO-sektorklassificering med validerad täckning,
+  källproveniens och separat synktjänst;
+- `7d9214f`: kandidatutfall märks mot den faktiska tillgängliga fördröjda
+  orderboksminuten inom ett strikt tvåminutersfönster;
+- `0a26681`: kontinuerligt paper-lärande, automatisk policyprövning och
+  realistiska standardkostnader för nya affärer i schema 48;
+- `8805c15`: stagingdeploy ägs av `diffen77/plattform-deploy`, använder
+  self-hosted runner på Kajen och kräver ett CI-utlöst digestbevis.
 
-På ett nybyggt PostgreSQL 16-schema 45 passerade 664 agenttester och 65
-dashboardtester. Dashboardens produktionsbygge passerade. Den historiska
-leveranskontrollens fem fokustester passerade efter den fulla körningen.
-GitHub Actions-körning `31464520362` passerade på aktuellt main-head. Den
-immutabla releasekörningen `31464638182` byggde och pushade revisionsmärkta
+På ett nybyggt PostgreSQL 16-schema 48 passerade 692 agenttester, 67
+dashboardtester och 27 fokuserade releasetester. Dashboardens
+produktionsbygge och en lokal kontroll av den slutliga agentimagen passerade.
+GitHub Actions-körning `31536691004` passerade på aktuellt main-head. Den
+immutabla releasekörningen `31536865354` byggde och pushade revisionsmärkta
 agent- och dashboard-images, attesterade deras proveniens och publicerade
-release-manifestet utan Node 20-varningar.
+plattformens digestbevis.
 
 ## Verifierad staging
 
@@ -49,24 +48,32 @@ Senaste läsverifieringen visade:
 - publik root: `401`;
 - publik health: `200`;
 - operations-API utan auth: `401`;
-- tio långlivade Compose-tjänster: `running` och `healthy`;
+- elva långlivade Compose-tjänster: `running` och `healthy`;
 - intern readiness: `READY`;
-- databasschema: 45;
+- databasschema: 48;
 - agent-image:
-  `sha256:dd8b03dd14bc634daf48f52e0e53370c52b0f3457ee3409f8f15f968a4847d1f`;
+  `sha256:68fd95f589b488cee617ec38da066a2e698ee3b3ff9e1d990da239c4aefc2598`;
 - dashboard-image:
-  `sha256:ca095e1e1436c2543df229be3454973b2506d90fad0e8c7b04a1880344bfe8c7`;
+  `sha256:448086f46cebe4f0237eca4fcc0394a94034119b3f1e448ad107ed5981a908b8`;
 - båda images har OCI-revision
-  `a1ca715380f3e496cddcfc7373205b84adbac4dd`.
+  `8805c15250fd70be08080b6a140adc359d655ad6`.
 
-Före migrationen togs och validerades en PostgreSQL-dump samt separata
-snapshots av Compose-konfigurationen och migrationsfilerna. Smoke-testet efter
-deployment verifierade `200` på publik health, `401` utan auth och `200` med
-auth på operations-API:t. Operationsstatus var korrekt `BLOCKED` enbart av
-`XSTO_SESSION_NOT_OPEN` utanför börsens öppettid.
+Plattformsdeploy `31537091406` validerade nyttolasten, sparade föregående
+imagefamiljer för rollback, hämtade digestlåsta images, migrerade, startade om
+och verifierade extern health. Efterkontrollen visade inga öppna driftlarm.
+Trading-readiness var korrekt `NOT_READY` enbart därför att XSTO-sessionen var
+stängd; monitorn kräver inte marknadsdata utanför en öppen session.
 
-Benchmark-readiness körs nu i staging och är fortsatt fail-closed. De
-kvarvarande blockerarna gäller extern data, ren benchmark-ledger och godkänd
+Den aktiva XSTO-mappningen innehåller 416 bolag. Alla har en sektoretikett och
+412 har färsk, verifierad Nasdaq-proveniens, vilket motsvarar 99,04 procent.
+Den kontinuerliga lärandeloopen hade 2 026 lyckade körningar; den senaste
+slutfördes efter deploymenten. Ledgern innehöll 8 876 kandidatprediktioner,
+8 355 tidsbundna entries, 21 350 märkta utfall och nio paper-affärer.
+
+Benchmark-readiness körs fortsatt fail-closed. Standardmodellen för nya
+paper-affärer använder faktisk top-of-book, 25 baspunkters avgift, minst en
+krona och fem baspunkters konservativ slippage. De kvarvarande blockerarna
+gäller främst styrd historisk data, en ren benchmark-ledger och godkänd
 förregistrering; de är inte driftfel i releasen.
 
 ## Benchmark och lärandeloop

--- a/docs/MORNING_HANDOFF.md
+++ b/docs/MORNING_HANDOFF.md
@@ -4,8 +4,8 @@
 
 Allt säkert internt arbete som kunde göras utan köp, avtal, KYC, riktiga
 pengar eller operatörens finansiella beslut är mergat till `main`. CI och den
-immutabla releasebyggnaden är gröna. Staging kör schema 45 från den verifierade
-releasen `a1ca715380f3e496cddcfc7373205b84adbac4dd`.
+immutabla releasebyggnaden är gröna. Staging kör schema 48 från den verifierade
+releasen `8805c15250fd70be08080b6a140adc359d655ad6`.
 
 Det innebär:
 
@@ -18,26 +18,29 @@ Det innebär:
   referenssnapshot;
 - checksummebunden leveranskontroll för all historik som krävs före backtest;
 - automatisk aktivering av framåttestade kandidatpolicyer i paper trading,
-  med automatisk återställning efter verifierad försämring.
+  med automatisk återställning efter verifierad försämring;
+- 99,04 procents verifierad sektortäckning för det aktiva XSTO-universumet;
+- realistiska standardkostnader för nya paper-affärer;
+- plattformsägd automatisk stagingdeploy med isolerad dispatchnyckel i
+  GitHub och Bitwarden.
 
 ## Beslut och externa åtgärder, i ordning
 
 ### 1. GitHub- och releasekedjan — klart
 
-PR #10 mergades till `main` som `6be95b57f472c5393b01044d52562fb17d7372c5`.
-PR #11 uppgraderade release-actions. Den deployade staging-releasen är
-`a1ca715380f3e496cddcfc7373205b84adbac4dd`; agent- och dashboard-images samt
-release-manifestet byggdes från exakt denna revision.
+PR #20 och PR #21 mergades till `main`. Den deployade staging-releasen är
+`8805c15250fd70be08080b6a140adc359d655ad6`; agent- och dashboard-images samt
+release-manifestet byggdes från exakt denna revision. Plattformens PR #27
+mergades och deploykörning `31537091406` passerade.
 
-### 2. Första schema-45-releasens transition — klart
+### 2. Schema-48-transition och plattformsdeploy — klart
 
-En validerad PostgreSQL-dump samt snapshots av Compose-konfiguration och
-migrationsfiler togs före övergången. Schema 45 migrerades, samtliga långlivade
-tjänster startades från digest-låsta images och OCI-revisionen verifierades mot
-GitHub-releasen.
+Den befintliga ledgern och de namngivna volymerna bevarades. Schema 45
+migrerades framåt till schema 48, samtliga långlivade tjänster startades från
+digest-låsta images och OCI-revisionen verifierades mot GitHub-releasen.
 
-Efterkontrollen visar intern readiness `READY`, friska tjänster och korrekt
-operationsblockering `XSTO_SESSION_NOT_OPEN` utanför börsens öppettid.
+Efterkontrollen visar intern readiness `READY`, elva friska tjänster, inga
+öppna driftlarm och korrekt tradingblockering när XSTO-sessionen är stängd.
 
 ### 3. Skaffa den styrda historikleveransen
 
@@ -64,20 +67,17 @@ exakt 20 000 SEK, inga positioner och inga tidigare benchmarkaffärer.
 Rekommendation: separat isolerad benchmarkmiljö. Det bevarar nuvarande
 paperhistorik och ger renare evidens.
 
-### 5. Frys benchmarkantagandena
+### 5. Frys återstående benchmarkantaganden
 
-Beslut krävs för:
+Tekniska standardvärden för courtage, slippage och exekveringsprisregel finns
+nu i schema 48. Kvar att besluta när benchmarkstarten närmar sig är vald
+OMXSGI-källa, slutliga godkännandekriterier och incidentregler.
 
-- courtage/avgifter;
-- slippage;
-- exekveringsprisregel;
-- vald quote-provider och OMXSGI-provider;
-- godkännandekriterier och incidentregler.
+### 6. Frys modellbeviset inför benchmark
 
-### 6. Frys modellbeviset
-
-Beslut: välj exakt modellbackend/modellnamn och spara det verifierade bevis som
-förregistreringen ska binda. Modellbyte efter start får inte ske tyst.
+Staging kör Hermes med `gpt-5.6-sol` och endpointen är verifierat nåbar. Vid
+benchmarkstart ska det exakta modellbeviset bindas i förregistreringen;
+modellbyte efter start får inte ske tyst.
 
 ### 7. Godkänn experimentidentiteten
 


### PR DESCRIPTION
## Resultat
- ersätter gammal schema-45-snapshot med verifierad release 8805c15
- dokumenterar 11 friska tjänster, schema 48 och plattformsdeploy
- sparar liveantal för sektorer, kandidatutfall, lärandekörningar och paper-affärer
- skiljer teknisk READY från korrekt stängd handels-readiness utanför XSTO-sessionen
- uppdaterar morgonens kvarvarande beslut

## Verifiering
- extern health 200
- 11/11 tjänster healthy
- intern readiness READY
- inga öppna driftlarm
- git diff --check
- 67 dashboardtester och production build i pre-push