### PR TITLE
ci: skip runtime release for docs-only pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,14 @@ name: CI/CD
 on:
   push:
     branches: [main]
+    paths:
+      - 'agent/**'
+      - 'dashboard/**'
+      - 'db/**'
+      - 'ops/**'
+      - '.github/workflows/**'
+      - '.dockerignore'
+      - 'docker-compose.yml'
   pull_request:
     branches: [main]
 

--- a/agent/tests/test_release_manifest.py
+++ b/agent/tests/test_release_manifest.py
@@ -116,6 +116,23 @@ def test_agent_runtime_image_excludes_test_only_dependencies_and_state():
     assert "python -m pip_audit -r requirements-test.txt" in ci
 
 
+def test_docs_only_main_pushes_do_not_trigger_runtime_release():
+    ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    push_trigger = ci.split("  push:\n", 1)[1].split(
+        "  pull_request:\n",
+        1,
+    )[0]
+
+    assert "    paths:\n" in push_trigger
+    assert "      - 'agent/**'\n" in push_trigger
+    assert "      - 'dashboard/**'\n" in push_trigger
+    assert "      - 'db/**'\n" in push_trigger
+    assert "      - 'ops/**'\n" in push_trigger
+    assert "      - '.github/workflows/**'\n" in push_trigger
+    assert "      - '.dockerignore'\n" in push_trigger
+    assert "      - 'docker-compose.yml'\n" in push_trigger
+
+
 def test_nasdaq_reference_sync_is_isolated_and_fail_closed_in_compose():
     compose = (ROOT / "docker-compose.yml").read_text()
 


### PR DESCRIPTION
## Resultat
- pull requests kör fortsatt full CI oavsett filtyp
- main-push triggar CI och image-release endast när runtime-, databas-, release- eller workflowfiler ändras
- ren dokumentation kan inte längre bygga och deploya identiska runtime-images

## Verifiering
- regressionsprovet failade före ändringen och passerar efter
- 28 releasekontraktstester passerar
- workflow-YAML kan parsas
- 67 dashboardtester och production build passerar i pre-push
- docs-only main-körning 31538068650 stoppades och releasejobbet skippades